### PR TITLE
Fixed undefined compile behavior for Arduino Uno and Mega

### DIFF
--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
@@ -50,6 +50,10 @@ void CLPUSBSerialBridge::sendError() {
 }
 
 void CLPUSBSerialBridge::sendResponse() {
+#ifdef DEBUG
+	Serial.print(F("R"));
+	Serial.println(rawHIDAndSerialBuffer[0], HEX);
+#endif // DEBUG
 	RawHID.write(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
 	// free the shared buffer to receive new data
 	RawHID.enable();
@@ -58,7 +62,14 @@ void CLPUSBSerialBridge::sendResponse() {
 void CLPUSBSerialBridge::handleHID()
 {
 	if (RawHID.available()) {
+#ifdef DEBUG
+		Serial.print(F("C"));
+		Serial.println(rawHIDAndSerialBuffer[0], HEX);
+#endif // DEBUG
 		if (!waitForSynchronization()) {
+#ifdef DEBUG
+			Serial.println(F("S"));
+#endif // DEBUG
 			sendError();
 			return;
 		}

--- a/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
+++ b/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
@@ -36,6 +36,7 @@ void setup() {
 	YOU MUST NOT USE Serial!
 	Serial is used by CorsairLightingProtocolSerial!
 	*/
+	cLPS.setup();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, CHANNEL_LED_COUNT);
 	ledController.addLeds(0, ledsChannel1);

--- a/src/CorsairLightingProtocolSerial.cpp
+++ b/src/CorsairLightingProtocolSerial.cpp
@@ -15,7 +15,9 @@
 */
 #include "CorsairLightingProtocolSerial.h"
 
-CorsairLightingProtocolSerial::CorsairLightingProtocolSerial(CorsairLightingProtocol* cLP) : cLP(cLP)
+CorsairLightingProtocolSerial::CorsairLightingProtocolSerial(CorsairLightingProtocol* cLP) : cLP(cLP){}
+
+void CorsairLightingProtocolSerial::setup()
 {
 	Serial.begin(SERIAL_BAUD);
 	Serial.setTimeout(SERIAL_TIMEOUT);

--- a/src/CorsairLightingProtocolSerial.h
+++ b/src/CorsairLightingProtocolSerial.h
@@ -27,6 +27,7 @@
 class CorsairLightingProtocolSerial : CorsairLightingProtocolResponse {
 public:
 	CorsairLightingProtocolSerial(CorsairLightingProtocol* cLP);
+	void setup();
 	void update();
 private:
 	byte rawCommand[COMMAND_SIZE];


### PR DESCRIPTION
moved Serial setup from constructor to setup
fixed initialisation order bug #39
this also fix problems related to #42 