### PR TITLE
Set new standards

### DIFF
--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -51,7 +51,7 @@ PWMFan fan3(PWM_FAN_PIN_3, 0, 2000);
 PWMFan fan4(PWM_FAN_PIN_4, 0, 2000);
 
 void setup() {
-	disableBuildInLEDs();
+	CLP::disableBuildInLEDs();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, CHANNEL_LED_COUNT);
 	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);

--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -15,6 +15,7 @@
 */
 #include "SimpleFanController.h"
 #include "ThermistorTemperatureController.h"
+#include <CorsairLightingFirmware.h>
 #include <CorsairLightingProtocol.h>
 #include <CorsairLightingProtocolHID.h>
 #include <FastLEDController.h>
@@ -34,12 +35,11 @@
 
 #define CHANNEL_LED_COUNT 96
 
-const uint8_t firmware_version[FIRMWARE_VERSION_SIZE] PROGMEM = { 0x00, 0x09, 0xD4 };
-
+CorsairLightingFirmware firmware = corsairCommanderPROFirmware();
 ThermistorTemperatureController temperatureController;
 FastLEDController ledController(&temperatureController, true);
 SimpleFanController fanController(&temperatureController, FAN_UPDATE_RATE, EEPROM_ADDRESS + ledController.getEEPROMSize());
-CorsairLightingProtocol cLP(&ledController, &temperatureController, &fanController, firmware_version);
+CorsairLightingProtocol cLP(&ledController, &temperatureController, &fanController, &firmware);
 CorsairLightingProtocolHID cHID(&cLP);
 
 CRGB ledsChannel1[CHANNEL_LED_COUNT];

--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -32,7 +32,7 @@
 #define PWM_FAN_PIN_3 9
 #define PWM_FAN_PIN_4 10
 
-#define CHANNEL_LED_COUNT 60
+#define CHANNEL_LED_COUNT 96
 
 const uint8_t firmware_version[FIRMWARE_VERSION_SIZE] PROGMEM = { 0x00, 0x09, 0xD4 };
 

--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -54,8 +54,8 @@ void setup() {
 	disableBuildInLEDs();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, CHANNEL_LED_COUNT);
-	ledController.addLeds(0, ledsChannel1, CHANNEL_LED_COUNT);
-	ledController.addLeds(1, ledsChannel2, CHANNEL_LED_COUNT);
+	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);
+	ledController.addLEDs(1, ledsChannel2, CHANNEL_LED_COUNT);
 	temperatureController.addSensor(0, TEMP_SENSOR_PIN_1);
 	temperatureController.addSensor(1, TEMP_SENSOR_PIN_2);
 	fanController.addFan(0, &fan1);

--- a/examples/CommanderPRO/PWMFan.h
+++ b/examples/CommanderPRO/PWMFan.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _PWMFan_h
-#define _PWMFan_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -31,5 +30,3 @@ protected:
 	const uint16_t minRPM;
 	const uint16_t maxRPM;
 };
-
-#endif

--- a/examples/CommanderPRO/SimpleFanController.h
+++ b/examples/CommanderPRO/SimpleFanController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _SimpleFanController_h
-#define _SimpleFanController_h
+#pragma once
 
 #include "Arduino.h"
 #include "FanController.h"
@@ -66,6 +65,3 @@ protected:
 	bool trigger_save = false;
 	long lastUpdate = 0;
 };
-
-#endif
-

--- a/examples/CommanderPRO/ThermistorTemperatureController.h
+++ b/examples/CommanderPRO/ThermistorTemperatureController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _ThermistorTemperatureController_h
-#define _ThermistorTemperatureController_h
+#pragma once
 
 #include "TemperatureController.h"
 /*
@@ -35,6 +34,3 @@ protected:
 
 	uint8_t sensorPins[TEMPERATURE_NUM] = { 0 };
 };
-
-#endif
-

--- a/examples/DebugSketch/DebugSketch.ino
+++ b/examples/DebugSketch/DebugSketch.ino
@@ -13,7 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#include <CorsairLightingNodePRO.h>
+#include <CorsairLightingFirmware.h>
+#include <FastLEDController.h>
+#include <CorsairLightingProtocol.h>
+#include <CorsairLightingProtocolHID.h>
 #include <FastLED.h>
 #include <EEPROM.h>
 
@@ -22,8 +25,9 @@
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
 
+CorsairLightingFirmware firmware = corsairLightingNodePROFirmware();
 FastLEDController ledController(true);
-CorsairLightingProtocol cLP(&ledController, firmware_version);
+CorsairLightingProtocol cLP(&ledController, &firmware);
 CorsairLightingProtocolHID cLPS(&cLP);
 
 CRGB ledsChannel1[CHANNEL_LED_COUNT];

--- a/examples/DebugSketch/DebugSketch.ino
+++ b/examples/DebugSketch/DebugSketch.ino
@@ -17,7 +17,7 @@
 #include <FastLED.h>
 #include <EEPROM.h>
 
-#define CHANNEL_LED_COUNT 60
+#define CHANNEL_LED_COUNT 96
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3

--- a/examples/DebugSketch/DebugSketch.ino
+++ b/examples/DebugSketch/DebugSketch.ino
@@ -37,8 +37,8 @@ void setup() {
 	Serial.setTimeout(100);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, CHANNEL_LED_COUNT);
-	ledController.addLeds(0, ledsChannel1, CHANNEL_LED_COUNT);
-	ledController.addLeds(1, ledsChannel2, CHANNEL_LED_COUNT);
+	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);
+	ledController.addLEDs(1, ledsChannel2, CHANNEL_LED_COUNT);
 }
 
 void loop() {

--- a/examples/DeviceIDTool/DeviceIDTool.ino
+++ b/examples/DeviceIDTool/DeviceIDTool.ino
@@ -35,7 +35,7 @@ void setup() {
 		; // wait for serial port to connect. Needed for native USB
 	}
 	Serial.print(F("Current DeviceID: "));
-	printDeviceID(deviceID);
+	CLP::printDeviceID(deviceID);
 	Serial.println();
 	Serial.println(F("Set a new DeviceID by typing it in the Serial Monitor. The new DeviceID must be in same format as above. 4 Blocks with 2 digits separated by white space."));
 	Serial.println();
@@ -58,7 +58,7 @@ void loop() {
 			newDeviceID[2] = strtol(&inputString[6], nullptr, 16);
 			newDeviceID[3] = strtol(&inputString[9], nullptr, 16);
 			Serial.println(F("Set DeviceID to: "));
-			printDeviceID(newDeviceID);
+			CLP::printDeviceID(newDeviceID);
 			Serial.println();
 			if (isNullID(newDeviceID)) {
 				Serial.println(F("This is a special DeviceID, it will generate a new random DeviceID next time iCUE controls the device!"));

--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.h
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CLPUSBSerialBridge_h
-#define _CLPUSBSerialBridge_h
+#pragma once
 
 #include "Arduino.h"
 #include <CorsairLightingProtocolConstants.h>
@@ -39,5 +38,3 @@ private:
 	void sendError();
 	void sendResponse();
 };
-
-#endif

--- a/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
+++ b/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
@@ -19,7 +19,7 @@
 #include <FastLEDController.h>
 #include <FastLED.h>
 
-#define CHANNEL_LED_COUNT 60
+#define CHANNEL_LED_COUNT 96
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3

--- a/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
+++ b/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
@@ -13,10 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+#include <CorsairLightingFirmware.h>
+#include <FastLEDController.h>
 #include <CorsairLightingProtocol.h>
 #include <CorsairLightingProtocolSerial.h>
-#include <CorsairLightingNodePRO.h>
-#include <FastLEDController.h>
 #include <FastLED.h>
 
 #define CHANNEL_LED_COUNT 96
@@ -24,8 +24,9 @@
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
 
+CorsairLightingFirmware firmware = corsairLightingNodePROFirmware();
 FastLEDController ledController(true);
-CorsairLightingProtocol cLP(&ledController, firmware_version);
+CorsairLightingProtocol cLP(&ledController, &firmware);
 CorsairLightingProtocolSerial cLPS(&cLP);
 
 CRGB ledsChannel1[CHANNEL_LED_COUNT];

--- a/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
+++ b/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
@@ -39,8 +39,8 @@ void setup() {
 	cLPS.setup();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, CHANNEL_LED_COUNT);
-	ledController.addLeds(0, ledsChannel1, CHANNEL_LED_COUNT);
-	ledController.addLeds(1, ledsChannel2, CHANNEL_LED_COUNT);
+	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);
+	ledController.addLEDs(1, ledsChannel2, CHANNEL_LED_COUNT);
 }
 
 void loop() {

--- a/examples/LightingNodePRO/LightingNodePRO.ino
+++ b/examples/LightingNodePRO/LightingNodePRO.ino
@@ -22,7 +22,7 @@
 CorsairLightingNodePRO cLNP;
 
 void setup() {
-	disableBuildInLEDs();
+	CLP::disableBuildInLEDs();
 	auto ledController = cLNP.getFastLEDController();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledController->getLEDs(0), ledController->getLEDCount(0));
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledController->getLEDs(1), ledController->getLEDCount(1));

--- a/examples/LightingNodePRO/LightingNodePRO.ino
+++ b/examples/LightingNodePRO/LightingNodePRO.ino
@@ -19,15 +19,13 @@
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
 
-CRGB ledsChannel1[CHANNEL_LED_COUNT];
-CRGB ledsChannel2[CHANNEL_LED_COUNT];
-
-CorsairLightingNodePRO cLNP(ledsChannel1, ledsChannel2);
+CorsairLightingNodePRO cLNP;
 
 void setup() {
 	disableBuildInLEDs();
-	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, CHANNEL_LED_COUNT);
-	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, CHANNEL_LED_COUNT);
+	auto ledController = cLNP.getFastLEDController();
+	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledController->getLeds(0), ledController->getLedCount(0));
+	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledController->getLeds(1), ledController->getLedCount(1));
 }
 
 void loop() {

--- a/examples/LightingNodePRO/LightingNodePRO.ino
+++ b/examples/LightingNodePRO/LightingNodePRO.ino
@@ -24,8 +24,8 @@ CorsairLightingNodePRO cLNP;
 void setup() {
 	disableBuildInLEDs();
 	auto ledController = cLNP.getFastLEDController();
-	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledController->getLeds(0), ledController->getLedCount(0));
-	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledController->getLeds(1), ledController->getLedCount(1));
+	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledController->getLEDs(0), ledController->getLEDCount(0));
+	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledController->getLEDs(1), ledController->getLEDCount(1));
 }
 
 void loop() {

--- a/examples/RepeatAndScale/RepeatAndScale.ino
+++ b/examples/RepeatAndScale/RepeatAndScale.ino
@@ -31,8 +31,8 @@ CorsairLightingProtocolHID cHID(&cLP);
 void setup() {
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, 100);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, 144);
-	ledController.addLeds(0, ledsChannel1, 50);
-	ledController.addLeds(1, ledsChannel2, 60);
+	ledController.addLEDs(0, ledsChannel1, 50);
+	ledController.addLEDs(1, ledsChannel2, 60);
 }
 
 void loop() {

--- a/examples/RepeatAndScale/RepeatAndScale.ino
+++ b/examples/RepeatAndScale/RepeatAndScale.ino
@@ -13,7 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#include <CorsairLightingNodePRO.h>
+#include <CorsairLightingFirmware.h>
+#include <FastLEDController.h>
+#include <CorsairLightingProtocol.h>
 #include <CorsairLightingProtocolHID.h>
 #include <FastLEDControllerUtils.h>
 #include <FastLED.h>
@@ -24,8 +26,9 @@
 CRGB ledsChannel1[100];
 CRGB ledsChannel2[144];
 
+CorsairLightingFirmware firmware = corsairLightingNodePROFirmware();
 FastLEDController ledController(true);
-CorsairLightingProtocol cLP(&ledController, firmware_version);
+CorsairLightingProtocol cLP(&ledController, &firmware);
 CorsairLightingProtocolHID cHID(&cLP);
 
 void setup() {

--- a/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
+++ b/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
@@ -13,7 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#include <CorsairLightingNodePRO.h>
+#include <CorsairLightingFirmware.h>
+#include <FastLEDController.h>
+#include <CorsairLightingProtocol.h>
 #include <CorsairLightingProtocolHID.h>
 #include <FastLED.h>
 
@@ -28,8 +30,9 @@
 // In this example we use only one pin where both channel are connected in series.
 #define DATA_PIN 2
 
+CorsairLightingFirmware firmware = corsairLightingNodePROFirmware();
 FastLEDController ledController(true);
-CorsairLightingProtocol cLP(&ledController, firmware_version);
+CorsairLightingProtocol cLP(&ledController, &firmware);
 CorsairLightingProtocolHID cHID(&cLP);
 
 // This array conatins all RGB values for the LEDs of the both channels.

--- a/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
+++ b/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
@@ -41,8 +41,8 @@ void setup() {
 #endif
 	disableBuildInLEDs();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
-	ledController.addLeds(0, leds, CHANNEL_LED_COUNT);
-	ledController.addLeds(1, &(leds[CHANNEL_LED_COUNT]), CHANNEL_LED_COUNT);
+	ledController.addLEDs(0, leds, CHANNEL_LED_COUNT);
+	ledController.addLEDs(1, &(leds[CHANNEL_LED_COUNT]), CHANNEL_LED_COUNT);
 }
 
 void loop() {

--- a/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
+++ b/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
@@ -42,7 +42,7 @@ void setup() {
 #ifdef DEBUG
 	Serial.begin(115200);
 #endif
-	disableBuildInLEDs();
+	CLP::disableBuildInLEDs();
 	FastLED.addLeds<NEOPIXEL, DATA_PIN>(leds, NUM_LEDS);
 	ledController.addLEDs(0, leds, CHANNEL_LED_COUNT);
 	ledController.addLEDs(1, &(leds[CHANNEL_LED_COUNT]), CHANNEL_LED_COUNT);

--- a/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
+++ b/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
@@ -31,8 +31,8 @@ CorsairLightingProtocolHID cHID(&cLP);
 void setup() {
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_1>(ledsChannel1, 96);
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, 60);
-	ledController.addLeds(0, ledsChannel1, 96);
-	ledController.addLeds(1, ledsChannel2, 60);
+	ledController.addLEDs(0, ledsChannel1, 96);
+	ledController.addLEDs(1, ledsChannel2, 60);
 }
 
 void loop() {

--- a/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
+++ b/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
@@ -13,7 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#include <CorsairLightingNodePRO.h>
+#include <CorsairLightingFirmware.h>
+#include <FastLEDController.h>
+#include <CorsairLightingProtocol.h>
 #include <CorsairLightingProtocolHID.h>
 #include <FastLEDControllerUtils.h>
 #include <FastLED.h>
@@ -24,8 +26,9 @@
 CRGB ledsChannel1[96];
 CRGB ledsChannel2[60];
 
+CorsairLightingFirmware firmware = corsairLightingNodePROFirmware();
 FastLEDController ledController(true);
-CorsairLightingProtocol cLP(&ledController, firmware_version);
+CorsairLightingProtocol cLP(&ledController, &firmware);
 CorsairLightingProtocolHID cHID(&cLP);
 
 void setup() {

--- a/src/CLPUtils.cpp
+++ b/src/CLPUtils.cpp
@@ -15,14 +15,14 @@
 */
 #include "CLPUtils.h"
 
-uint16_t fromBigEndian(const byte& byte1, const byte& byte2) {
+uint16_t CLP::fromBigEndian(const byte& byte1, const byte& byte2) {
 	uint16_t t = byte1;
 	t = t << 8;
 	t |= byte2;
 	return t;
 }
 
-void disableBuildInLEDs()
+void CLP::disableBuildInLEDs()
 {
 #ifndef DEBUG
 #ifdef LED_BUILTIN_RX
@@ -34,7 +34,7 @@ void disableBuildInLEDs()
 #endif
 }
 
-void printDeviceID(const uint8_t* deviceId) {
+void CLP::printDeviceID(const uint8_t* deviceId) {
 	char tmp[16];
 	for (size_t i = 0; i < 4; i++) {
 		sprintf(tmp, "%.2X", deviceId[i]);

--- a/src/CLPUtils.h
+++ b/src/CLPUtils.h
@@ -18,18 +18,22 @@
 #include "Arduino.h"
 
 #define toBigEndian(a) highByte(a), lowByte(a)
-uint16_t fromBigEndian(const byte& byte1, const byte& byte2);
-// convert value from range 0-100 to 0-255
-inline uint8_t convert100To255(uint8_t value)
+
+namespace CLP
 {
-	return value * 2.5546875f;
+	uint16_t fromBigEndian(const byte& byte1, const byte& byte2);
+	// convert value from range 0-100 to 0-255
+	inline uint8_t convert100To255(uint8_t value)
+	{
+		return value * 2.5546875f;
+	}
+	// convert value from range 0-255 to 0-100
+	inline uint8_t convert255To100(uint8_t value)
+	{
+		return value / 2.5546875f;
+	}
+	// This will disable the RX and TX built in leds on Arduino Leonardo, Micro and Pro Micro.
+	void disableBuildInLEDs();
+	// Print the given DeviceID to Serial
+	void printDeviceID(const uint8_t* deviceId);
 }
-// convert value from range 0-255 to 0-100
-inline uint8_t convert255To100(uint8_t value)
-{
-	return value / 2.5546875f;
-}
-// This will disable the RX and TX built in leds on Arduino Leonardo, Micro and Pro Micro.
-void disableBuildInLEDs();
-// Print the given DeviceID to Serial
-void printDeviceID(const uint8_t* deviceId);

--- a/src/CLPUtils.h
+++ b/src/CLPUtils.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CLPUtils_h
-#define _CLPUtils_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -34,5 +33,3 @@ inline uint8_t convert255To100(uint8_t value)
 void disableBuildInLEDs();
 // Print the given DeviceID to Serial
 void printDeviceID(const uint8_t* deviceId);
-
-#endif

--- a/src/CorsairLightingFirmware.cpp
+++ b/src/CorsairLightingFirmware.cpp
@@ -16,6 +16,12 @@
 #include <EEPROM.h>
 #include "CorsairLightingFirmware.h"
 
+const uint8_t bootloader_version[] PROGMEM = { 0x00, 0x02 };
+
+const uint8_t corsairLightingNodePROFirmwareVersion[FIRMWARE_VERSION_SIZE] PROGMEM = { 0x00, 0x0A, 0x04 };
+
+const uint8_t corsairCommanderPROFirmwareVersion[FIRMWARE_VERSION_SIZE] PROGMEM = { 0x00, 0x09, 0xD4 };
+
 CorsairLightingFirmware::CorsairLightingFirmware(const uint8_t* firmwareVersion) : firmwareVersion(firmwareVersion)
 {
 	EEPROM.get(EEPROM_ADDRESS_DEVICE_ID, DeviceId);
@@ -54,4 +60,14 @@ void CorsairLightingFirmware::handleFirmwareCommand(const Command& command, cons
 		break;
 	}
 	}
+}
+
+CorsairLightingFirmware corsairLightingNodePROFirmware()
+{
+	return CorsairLightingFirmware(corsairLightingNodePROFirmwareVersion);
+}
+
+CorsairLightingFirmware corsairCommanderPROFirmware()
+{
+	return CorsairLightingFirmware(corsairCommanderPROFirmwareVersion);
 }

--- a/src/CorsairLightingFirmware.h
+++ b/src/CorsairLightingFirmware.h
@@ -30,8 +30,6 @@
 
 #define FIRMWARE_VERSION_SIZE 3
 
-const uint8_t bootloader_version[] PROGMEM = { 0x00, 0x02 };
-
 class CorsairLightingFirmware {
 public:
 	CorsairLightingFirmware(const uint8_t* firmwareVersion);
@@ -40,6 +38,10 @@ protected:
 	const uint8_t* firmwareVersion;
 	uint8_t DeviceId[4];
 };
+
+CorsairLightingFirmware corsairLightingNodePROFirmware();
+
+CorsairLightingFirmware corsairCommanderPROFirmware();
 
 #endif
 

--- a/src/CorsairLightingFirmware.h
+++ b/src/CorsairLightingFirmware.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CORSAIRLIGHTINGFIRMWARE_h
-#define _CORSAIRLIGHTINGFIRMWARE_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -42,6 +41,3 @@ protected:
 CorsairLightingFirmware corsairLightingNodePROFirmware();
 
 CorsairLightingFirmware corsairCommanderPROFirmware();
-
-#endif
-

--- a/src/CorsairLightingNodePRO.cpp
+++ b/src/CorsairLightingNodePRO.cpp
@@ -15,7 +15,9 @@
 */
 #include "CorsairLightingNodePRO.h"
 
-CorsairLightingNodePRO::CorsairLightingNodePRO() : ledController(true), cLP(&ledController, firmware_version), connectionAdapter(&cLP)
+#if defined(USBCON)
+
+CorsairLightingNodePRO::CorsairLightingNodePRO() : ledController(true), cLP(&ledController, &firmware), connectionAdapter(&cLP)
 {
 	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT_DEFAULT);
 	ledController.addLEDs(1, ledsChannel2, CHANNEL_LED_COUNT_DEFAULT);
@@ -33,3 +35,5 @@ FastLEDController* CorsairLightingNodePRO::getFastLEDController()
 {
 	return &ledController;
 }
+
+#endif

--- a/src/CorsairLightingNodePRO.cpp
+++ b/src/CorsairLightingNodePRO.cpp
@@ -17,8 +17,8 @@
 
 CorsairLightingNodePRO::CorsairLightingNodePRO() : ledController(true), cLP(&ledController, firmware_version), connectionAdapter(&cLP)
 {
-	ledController.addLeds(0, ledsChannel1, CHANNEL_LED_COUNT_DEFAULT);
-	ledController.addLeds(1, ledsChannel2, CHANNEL_LED_COUNT_DEFAULT);
+	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT_DEFAULT);
+	ledController.addLEDs(1, ledsChannel2, CHANNEL_LED_COUNT_DEFAULT);
 }
 
 void CorsairLightingNodePRO::update() {

--- a/src/CorsairLightingNodePRO.cpp
+++ b/src/CorsairLightingNodePRO.cpp
@@ -15,10 +15,10 @@
 */
 #include "CorsairLightingNodePRO.h"
 
-CorsairLightingNodePRO::CorsairLightingNodePRO(CRGB* ledsChannel1, CRGB* ledsChannel2) : ledController(true), cLP(&ledController, firmware_version), connectionAdapter(&cLP)
+CorsairLightingNodePRO::CorsairLightingNodePRO() : ledController(true), cLP(&ledController, firmware_version), connectionAdapter(&cLP)
 {
-	ledController.addLeds(0, ledsChannel1, CHANNEL_LED_COUNT);
-	ledController.addLeds(1, ledsChannel2, CHANNEL_LED_COUNT);
+	ledController.addLeds(0, ledsChannel1, CHANNEL_LED_COUNT_DEFAULT);
+	ledController.addLeds(1, ledsChannel2, CHANNEL_LED_COUNT_DEFAULT);
 }
 
 void CorsairLightingNodePRO::update() {
@@ -27,4 +27,9 @@ void CorsairLightingNodePRO::update() {
 	if (ledController.updateLEDs()) {
 		FastLED.show();
 	}
+}
+
+FastLEDController* CorsairLightingNodePRO::getFastLEDController()
+{
+	return &ledController;
 }

--- a/src/CorsairLightingNodePRO.h
+++ b/src/CorsairLightingNodePRO.h
@@ -20,25 +20,23 @@
 #include "FastLEDController.h"
 #include "CorsairLightingProtocol.h"
 #include "CorsairLightingProtocolHID.h"
-#include "CorsairLightingProtocolSerial.h"
 #include <FastLED.h>
 
-#define CHANNEL_LED_COUNT 60
+#define CHANNEL_LED_COUNT_DEFAULT 96
 
 const uint8_t firmware_version[FIRMWARE_VERSION_SIZE] PROGMEM = { 0x00, 0x0A, 0x04 };
 
 class CorsairLightingNodePRO {
 public:
-	CorsairLightingNodePRO(CRGB* ledsChannel1, CRGB* ledsChannel2);
+	CorsairLightingNodePRO();
 	void update();
+	FastLEDController* getFastLEDController();
 protected:
+	CRGB ledsChannel1[CHANNEL_LED_COUNT_DEFAULT];
+	CRGB ledsChannel2[CHANNEL_LED_COUNT_DEFAULT];
 	FastLEDController ledController;
 	CorsairLightingProtocol cLP;
-#if defined(USBCON)
 	CorsairLightingProtocolHID connectionAdapter;
-#else
-	CorsairLightingProtocolSerial connectionAdapter;
-#endif
 };
 
 #endif

--- a/src/CorsairLightingNodePRO.h
+++ b/src/CorsairLightingNodePRO.h
@@ -17,14 +17,15 @@
 #define _CORSAIRLIGHTINGNODEPRO_h
 
 #include "Arduino.h"
+#include "CorsairLightingFirmware.h" 
 #include "FastLEDController.h"
 #include "CorsairLightingProtocol.h"
 #include "CorsairLightingProtocolHID.h"
 #include <FastLED.h>
 
-#define CHANNEL_LED_COUNT_DEFAULT 96
+#if defined(USBCON)
 
-const uint8_t firmware_version[FIRMWARE_VERSION_SIZE] PROGMEM = { 0x00, 0x0A, 0x04 };
+#define CHANNEL_LED_COUNT_DEFAULT 96
 
 class CorsairLightingNodePRO {
 public:
@@ -34,10 +35,11 @@ public:
 protected:
 	CRGB ledsChannel1[CHANNEL_LED_COUNT_DEFAULT];
 	CRGB ledsChannel2[CHANNEL_LED_COUNT_DEFAULT];
+	CorsairLightingFirmware firmware = corsairLightingNodePROFirmware();
 	FastLEDController ledController;
 	CorsairLightingProtocol cLP;
 	CorsairLightingProtocolHID connectionAdapter;
 };
 
 #endif
-
+#endif

--- a/src/CorsairLightingNodePRO.h
+++ b/src/CorsairLightingNodePRO.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CORSAIRLIGHTINGNODEPRO_h
-#define _CORSAIRLIGHTINGNODEPRO_h
+#pragma once
 
 #include "Arduino.h"
 #include "CorsairLightingFirmware.h" 
@@ -41,5 +40,4 @@ protected:
 	CorsairLightingProtocolHID connectionAdapter;
 };
 
-#endif
 #endif

--- a/src/CorsairLightingProtocol.cpp
+++ b/src/CorsairLightingProtocol.cpp
@@ -14,17 +14,16 @@
    limitations under the License.
 */
 #include "CorsairLightingProtocol.h"
-#include "CorsairLightingFirmware.h"
 #include "LEDController.h"
 
-CorsairLightingProtocol::CorsairLightingProtocol(ILEDController* aLEDController, const uint8_t* firmwareVersion) : corsairLightingFirmware(firmwareVersion), ledController(aLEDController), temperatureController(nullptr), fanController(nullptr) {}
+CorsairLightingProtocol::CorsairLightingProtocol(ILEDController* aLEDController, CorsairLightingFirmware* corsairLightingFirmware) : corsairLightingFirmware(corsairLightingFirmware), ledController(aLEDController), temperatureController(nullptr), fanController(nullptr) {}
 
-CorsairLightingProtocol::CorsairLightingProtocol(ILEDController* aLEDController, ITemperatureController* temperatureController, IFanController* fanController, const uint8_t* firmwareVersion) : corsairLightingFirmware(firmwareVersion), ledController(aLEDController), temperatureController(temperatureController), fanController(fanController) {}
+CorsairLightingProtocol::CorsairLightingProtocol(ILEDController* aLEDController, ITemperatureController* temperatureController, IFanController* fanController, CorsairLightingFirmware* corsairLightingFirmware) : corsairLightingFirmware(corsairLightingFirmware), ledController(aLEDController), temperatureController(temperatureController), fanController(fanController) {}
 
 void CorsairLightingProtocol::handleCommand(const Command& command, CorsairLightingProtocolResponse* response)
 {
 	if (command.command < 0x10) {
-		corsairLightingFirmware.handleFirmwareCommand(command, response);
+		corsairLightingFirmware->handleFirmwareCommand(command, response);
 	}
 	else if (command.command >= 0x10 && command.command < 0x20) {
 		if (temperatureController != nullptr) {

--- a/src/CorsairLightingProtocol.h
+++ b/src/CorsairLightingProtocol.h
@@ -29,11 +29,11 @@
 class CorsairLightingProtocol
 {
 public:
-	CorsairLightingProtocol(ILEDController* l, const uint8_t* firmwareVersion);
-	CorsairLightingProtocol(ILEDController* l, ITemperatureController* t, IFanController* f, const uint8_t* firmwareVersion);
+	CorsairLightingProtocol(ILEDController* l, CorsairLightingFirmware* c);
+	CorsairLightingProtocol(ILEDController* l, ITemperatureController* t, IFanController* f, CorsairLightingFirmware* c);
 	void handleCommand(const Command& command, CorsairLightingProtocolResponse* response);
 private:
-	CorsairLightingFirmware corsairLightingFirmware;
+	CorsairLightingFirmware* const corsairLightingFirmware;
 	ILEDController* const ledController;
 	ITemperatureController* const temperatureController;
 	IFanController* const fanController;

--- a/src/CorsairLightingProtocol.h
+++ b/src/CorsairLightingProtocol.h
@@ -13,9 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-
-#ifndef _CorsairLightingProtocol_h
-#define _CorsairLightingProtocol_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -38,5 +36,3 @@ private:
 	ITemperatureController* const temperatureController;
 	IFanController* const fanController;
 };
-
-#endif

--- a/src/CorsairLightingProtocolConstants.h
+++ b/src/CorsairLightingProtocolConstants.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CorsairLightingProtocolConstants_h
-#define _CorsairLightingProtocolConstants_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -69,5 +68,3 @@ struct Command {
 		uint8_t raw[COMMAND_SIZE];
 	};
 };
-
-#endif

--- a/src/CorsairLightingProtocolHID.h
+++ b/src/CorsairLightingProtocolHID.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CORSAIRLIGHTINGPROTOCOLHID_h
-#define _CORSAIRLIGHTINGPROTOCOLHID_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -42,5 +41,4 @@ protected:
 	void sendX(const uint8_t* data, const size_t x) const override;
 };
 
-#endif
 #endif

--- a/src/CorsairLightingProtocolResponse.h
+++ b/src/CorsairLightingProtocolResponse.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CorsairLightingProtocolCallback_h
-#define _CorsairLightingProtocolCallback_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -26,5 +25,3 @@ public:
 	// Send x byte data via the CorsairLightingProtocol.
 	virtual void sendX(const uint8_t* data, const size_t x) const = 0;
 };
-
-#endif

--- a/src/CorsairLightingProtocolSerial.h
+++ b/src/CorsairLightingProtocolSerial.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _CorsairLightingProtocolSerial_h
-#define _CorsairLightingProtocolSerial_h
+#pragma once
 
 #include <CorsairLightingProtocol.h>
 #include <CorsairLightingProtocolConstants.h>
@@ -36,5 +35,3 @@ private:
 	bool handleSerial();
 	void sendX(const uint8_t* data, const size_t x) const override;
 };
-
-#endif

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -62,7 +62,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 			return;
 		}
 		uint8_t power = getFanPower(fan);
-		uint8_t powerData[] = { convert255To100(power) };
+		uint8_t powerData[] = { CLP::convert255To100(power) };
 		response->send(powerData, sizeof(powerData));
 		break;
 	}
@@ -73,7 +73,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 			response->sendError();
 			return;
 		}
-		uint8_t percentage = convert100To255(command.data[1]);
+		uint8_t percentage = CLP::convert100To255(command.data[1]);
 		setFanPower(fan, percentage);
 		response->send(nullptr, 0);
 		break;
@@ -85,7 +85,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 			response->sendError();
 			return;
 		}
-		uint16_t speed = fromBigEndian(command.data[1], command.data[2]);
+		uint16_t speed = CLP::fromBigEndian(command.data[1], command.data[2]);
 		setFanSpeed(fan, speed);
 		response->send(nullptr, 0);
 		break;
@@ -100,8 +100,8 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 		const uint8_t& group = command.data[1];
 		FanCurve fanCurve;
 		for (uint8_t i = 0; i < FAN_CURVE_POINTS_NUM; i++) {
-			fanCurve.temperatures[i] = fromBigEndian(command.data[2 + i * 2], command.data[3 + i * 2]);
-			fanCurve.rpms[i] = fromBigEndian(command.data[14 + i * 2], command.data[15 + i * 2]);
+			fanCurve.temperatures[i] = CLP::fromBigEndian(command.data[2 + i * 2], command.data[3 + i * 2]);
+			fanCurve.rpms[i] = CLP::fromBigEndian(command.data[14 + i * 2], command.data[15 + i * 2]);
 		}
 		setFanCurve(fan, group, fanCurve);
 		response->send(nullptr, 0);
@@ -114,7 +114,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 			response->sendError();
 			return;
 		}
-		uint16_t temp = fromBigEndian(command.data[1], command.data[2]);
+		uint16_t temp = CLP::fromBigEndian(command.data[1], command.data[2]);
 		setFanExternalTemperature(fan, temp);
 		response->send(nullptr, 0);
 		break;

--- a/src/FanController.h
+++ b/src/FanController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _FanController_h
-#define _FanController_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -67,5 +66,3 @@ protected:
 	// One of FAN_MASK_*
 	virtual void setFanDetectionType(uint8_t fan, uint8_t type) = 0;
 };
-
-#endif

--- a/src/FastLEDController.cpp
+++ b/src/FastLEDController.cpp
@@ -35,7 +35,7 @@ FastLEDController::~FastLEDController()
 	}
 }
 
-void FastLEDController::addLeds(uint8_t channel, CRGB* led_buffer, uint8_t count) {
+void FastLEDController::addLEDs(uint8_t channel, CRGB* led_buffer, uint8_t count) {
 	if (channel >= CHANNEL_NUM || led_buffer == nullptr || volatileData[channel].led_buffer != nullptr) {
 		return;
 	}
@@ -46,7 +46,7 @@ void FastLEDController::addLeds(uint8_t channel, CRGB* led_buffer, uint8_t count
 	}
 }
 
-CRGB* FastLEDController::getLeds(uint8_t channel)
+CRGB* FastLEDController::getLEDs(uint8_t channel)
 {
 	if (channel >= CHANNEL_NUM) {
 		return nullptr;
@@ -54,7 +54,7 @@ CRGB* FastLEDController::getLeds(uint8_t channel)
 	return volatileData[channel].led_buffer;
 }
 
-uint8_t FastLEDController::getLedCount(uint8_t channel)
+uint8_t FastLEDController::getLEDCount(uint8_t channel)
 {
 	if (channel >= CHANNEL_NUM) {
 		return 0;

--- a/src/FastLEDController.h
+++ b/src/FastLEDController.h
@@ -42,9 +42,9 @@ public:
 	// restart of the Arduino. Also the the TemperatureController used for temperature related lighting can be passed here.
 	FastLEDController(TemperatureController* temperatureController, bool useEEPROM);
 	~FastLEDController();
-	virtual void addLeds(uint8_t channel, CRGB* led_buffer, uint8_t count);
-	CRGB* getLeds(uint8_t channel);
-	uint8_t getLedCount(uint8_t channel);
+	virtual void addLEDs(uint8_t channel, CRGB* led_buffer, uint8_t count);
+	CRGB* getLEDs(uint8_t channel);
+	uint8_t getLEDCount(uint8_t channel);
 	virtual bool updateLEDs();
 	virtual size_t getEEPROMSize();
 protected:

--- a/src/FastLEDControllerUtils.cpp
+++ b/src/FastLEDControllerUtils.cpp
@@ -19,8 +19,8 @@ void CLP::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIn
 {
 	auto& channel = controller->getChannel(channelIndex);
 	if (channel.ledMode == CHANNEL_MODE_SOFTWARE_PLAYBACK) {
-		auto leds = controller->getLeds(channelIndex);
-		for (uint8_t fanIndex = 0; fanIndex < controller->getLedCount(channelIndex) / 16; fanIndex++) {
+		auto leds = controller->getLEDs(channelIndex);
+		for (uint8_t fanIndex = 0; fanIndex < controller->getLEDCount(channelIndex) / 16; fanIndex++) {
 			for (uint8_t ledIndex = 0; ledIndex < 8; ledIndex++) {
 				CRGB temp = leds[fanIndex * 16 + ledIndex];
 				leds[fanIndex * 16 + ledIndex] = leds[fanIndex * 16 + 15 - ledIndex];
@@ -32,8 +32,8 @@ void CLP::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIn
 
 void CLP::scale(FastLEDController* controller, uint8_t channelIndex, int scaleToSize)
 {
-	auto leds = controller->getLeds(channelIndex);
-	float scaleFactor = (float)controller->getLedCount(channelIndex) / scaleToSize;
+	auto leds = controller->getLEDs(channelIndex);
+	float scaleFactor = (float)controller->getLEDCount(channelIndex) / scaleToSize;
 	for (int ledIndex = scaleToSize - 1; ledIndex >= 0; ledIndex--) {
 		leds[ledIndex] = leds[(int)(ledIndex * scaleFactor)];
 	}
@@ -41,8 +41,8 @@ void CLP::scale(FastLEDController* controller, uint8_t channelIndex, int scaleTo
 
 void CLP::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t times)
 {
-	auto leds = controller->getLeds(channelIndex);
-	auto count = controller->getLedCount(channelIndex);
+	auto leds = controller->getLEDs(channelIndex);
+	auto count = controller->getLEDCount(channelIndex);
 	//skip first iteration, because leds already contains the data at the first position
 	for (int i = 1; i < times; i++) {
 		memcpy(leds + (count * i), leds, sizeof(CRGB) * count);

--- a/src/FastLEDControllerUtils.h
+++ b/src/FastLEDControllerUtils.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _FastLEDControllerUtils_h
-#define _FastLEDControllerUtils_h
+#pragma once
 
 #include "Arduino.h"
 #include "FastLEDController.h"
@@ -30,4 +29,3 @@ namespace CLP
 	//Repeat a channel's leds color to control more leds than provided by iCUE.
 	void repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t times);
 }
-#endif

--- a/src/FastLEDControllerUtils.h
+++ b/src/FastLEDControllerUtils.h
@@ -24,7 +24,7 @@ namespace CLP
 	//Make it possible to use up to 96 leds per channel from iCUE by using the LL Fan option. This function transforms the LL fans layout to a normal strip layout.
 	//This function can be combined with scale and repeat function but must be invoked first.
 	void transformLLFanToStrip(FastLEDController* controller, uint8_t channelIndex);
-	//Scales a channel's length to a given size, the size can be larger or smaller than the default length given to the FastLEDController::addLeds function
+	//Scales a channel's length to a given size, the size can be larger or smaller than the default length given to the FastLEDController::addLEDs function
 	//Integer scaling is used, so no interpolation between color values is done and the animation don't look blurry.
 	void scale(FastLEDController* controller, uint8_t channelIndex, int scaleToSize);
 	//Repeat a channel's leds color to control more leds than provided by iCUE.

--- a/src/IFanController.h
+++ b/src/IFanController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _IFanController_h
-#define _IFanController_h
+#pragma once
 
 #include "Arduino.h"
 #include "CorsairLightingProtocolResponse.h"
@@ -24,5 +23,3 @@ class IFanController {
 public:
 	virtual void handleFanControl(const Command& command, const CorsairLightingProtocolResponse* response) = 0;
 };
-
-#endif

--- a/src/ILEDController.h
+++ b/src/ILEDController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _ILEDController_h
-#define _ILEDController_h
+#pragma once
 
 #include "Arduino.h"
 #include "CorsairLightingProtocolResponse.h"
@@ -24,5 +23,3 @@ class ILEDController {
 public:
 	virtual void handleLEDControl(const Command& command, const CorsairLightingProtocolResponse* response) = 0;
 };
-
-#endif

--- a/src/ITemperatureController.h
+++ b/src/ITemperatureController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _ITemperatureController_h
-#define _ITemperatureController_h
+#pragma once
 
 #include "Arduino.h"
 #include "CorsairLightingProtocolResponse.h"
@@ -24,5 +23,3 @@ class ITemperatureController {
 public:
 	virtual void handleTemperatureControl(const Command& command, const CorsairLightingProtocolResponse* response) = 0;
 };
-
-#endif

--- a/src/LEDController.cpp
+++ b/src/LEDController.cpp
@@ -98,9 +98,9 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 			group.color3.r = data[14];
 			group.color3.g = data[15];
 			group.color3.b = data[16];
-			group.temp1 = fromBigEndian(data[17], data[18]);
-			group.temp2 = fromBigEndian(data[19], data[20]);
-			group.temp3 = fromBigEndian(data[21], data[22]);
+			group.temp1 = CLP::fromBigEndian(data[17], data[18]);
+			group.temp2 = CLP::fromBigEndian(data[19], data[20]);
+			group.temp3 = CLP::fromBigEndian(data[21], data[22]);
 
 			if (!isValidLEDGroup(group)) {
 				response->sendError();
@@ -112,7 +112,7 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 		}
 		case WRITE_LED_EXTERNAL_TEMP:
 		{
-			setLEDExternalTemperature(channel, fromBigEndian(data[2], data[3]));
+			setLEDExternalTemperature(channel, CLP::fromBigEndian(data[2], data[3]));
 			break;
 		}
 		case WRITE_LED_GROUPS_CLEAR:
@@ -127,7 +127,7 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 		}
 		case WRITE_LED_BRIGHTNESS:
 		{
-			uint8_t brightness = convert100To255(data[1]);
+			uint8_t brightness = CLP::convert100To255(data[1]);
 			trigger_save |= setLEDBrightness(channel, brightness);
 			break;
 		}

--- a/src/RawHID.cpp
+++ b/src/RawHID.cpp
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2014-2015 NicoHood
+modified by Leon Kiefer
 See the readme for credit to other people.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/src/RawHID.h
+++ b/src/RawHID.h
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2014-2015 NicoHood
+modified by Leon Kiefer
 See the readme for credit to other people.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -20,9 +21,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
-
-// Include guard
 #pragma once
 
 #include <Arduino.h>

--- a/src/TemperatureController.h
+++ b/src/TemperatureController.h
@@ -13,8 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
-#ifndef _TemperatureController_h
-#define _TemperatureController_h
+#pragma once
 
 #include "Arduino.h"
 
@@ -45,5 +44,3 @@ protected:
 	// The voltage in mV.
 	virtual uint16_t getVoltageRail3V3() = 0;
 };
-
-#endif


### PR DESCRIPTION
changed default CHANNEL_LED_COUNT to 96
write LED in capital letters if not at the beginning of a word
changed firmware handling
added factory function for firmware of CLP and Commander PRO
unified includes
CorsairLightingNodePRO now only support HID adapter
use #pragma once as include guard
use namespace in CLPUtils