### PR TITLE
added onUpdateHook to FastLEDController

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can repeat or scale LED channel controlled by iCUE onto physical LED strips.
 This is very useful if you have very long LED strips that are longer than 60/96 LEDs.
 This is the maximum number iCUE supports.
 
-To repeat or scale a LED channel you must apply the `CLP::repeat` or the `CLP:scale` function in the arduino `loop` before `FastLED.show();`.
+To repeat or scale a LED channel you must apply the `CLP::repeat` or the `CLP:scale` function in the update hook of the FastLEDController.
 The functions must be included from `FastLEDControllerUtils.h`.
 See the [RepeatAndScale](examples/RepeatAndScale/RepeatAndScale.ino) example for the complete code.
 Both functions take the FastLEDController pointer and the channel index as arguments.

--- a/examples/RepeatAndScale/RepeatAndScale.ino
+++ b/examples/RepeatAndScale/RepeatAndScale.ino
@@ -36,14 +36,18 @@ void setup() {
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, 144);
 	ledController.addLEDs(0, ledsChannel1, 50);
 	ledController.addLEDs(1, ledsChannel2, 60);
+	ledController.onUpdateHook(0, []() {
+		CLP::repeat(&ledController, 0, 2);
+	});
+	ledController.onUpdateHook(1, []() {
+		CLP::scale(&ledController, 1, 144);
+	});
 }
 
 void loop() {
 	cHID.update();
 
 	if (ledController.updateLEDs()) {
-		CLP::repeat(&ledController, 0, 2);
-		CLP::scale(&ledController, 1, 144);
 		FastLED.show();
 	}
 }

--- a/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
+++ b/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
@@ -36,13 +36,15 @@ void setup() {
 	FastLED.addLeds<NEOPIXEL, DATA_PIN_CHANNEL_2>(ledsChannel2, 60);
 	ledController.addLEDs(0, ledsChannel1, 96);
 	ledController.addLEDs(1, ledsChannel2, 60);
+	ledController.onUpdateHook(0, []() {
+		CLP::transformLLFanToStrip(&ledController, 0);
+	});
 }
 
 void loop() {
 	cHID.update();
 
 	if (ledController.updateLEDs()) {
-		CLP::transformLLFanToStrip(&ledController, 0);
 		FastLED.show();
 	}
 }

--- a/src/FastLEDController.h
+++ b/src/FastLEDController.h
@@ -32,6 +32,7 @@ class FastLEDController : public LEDController {
 		uint8_t* values_buffer[3] = { nullptr };
 		// current temperature
 		uint16_t temp;
+		void (*onUpdateCallback)(void) = nullptr;
 	};
 
 public:
@@ -47,6 +48,10 @@ public:
 	uint8_t getLEDCount(uint8_t channel);
 	virtual bool updateLEDs();
 	virtual size_t getEEPROMSize();
+	// Register an update hook, which is exectuted after a channel has been updated. This can be used to apply transforamtions to the
+	// channel before the data is displayed by FastLED. The first argument is the channel for which the hook is registered, the second
+	// argument is the callback, which is a void function with no arguments.
+	void onUpdateHook(uint8_t channel, void (*callback)(void));
 protected:
 	TemperatureController* const temperatureController;
 


### PR DESCRIPTION
updated transformation examples to use the update hook

With this change the channel transformations can be applied independently and updates to one channel don't cause artifacts on the other channel.
This PR closes #55 