### PR TITLE
added fixIcueBrightness util function

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ Then the third argument of the `scale` function is `144`.
 For both functions it's **important**, that the CRGB arrays have at least the length of the physical LED strip.
 This means if your LED channel from iCUE has 50 LEDs and you use the `repeat` function to control 100 physical LEDs you MUST declare the CRGB array at least with a length of 100.
 
+## Increase the Brightness of the LEDs
+By default iCUE only uses 50% of the LEDs brightness even if you set the brightness to max in the iCUE Device Settings.
+But there are good news, we can increase the brightness with the Arduino so we can use the full brightness of our LEDs.
+Add the `CLP::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AdditionalFeatures/AdditionalFeatures.ino).
+If there are multiple functions called in `onUpdateHook`, `fixIcueBrightness` should be the first.
+```C++
+ledController.onUpdateHook(0, []() {
+	CLP::fixIcueBrightness(&ledController, 0);
+});
+```
+
 # License
 This project is licensed under the Apache 2.0 License.
 

--- a/src/FastLEDControllerUtils.cpp
+++ b/src/FastLEDControllerUtils.cpp
@@ -22,7 +22,8 @@ void CLP::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIn
 	auto& channel = controller->getChannel(channelIndex);
 	if (channel.mode == ChannelMode::SoftwarePlayback) {
 		auto leds = controller->getLEDs(channelIndex);
-		for (uint8_t fanIndex = 0; fanIndex < controller->getLEDCount(channelIndex) / 16; fanIndex++) {
+		auto count = controller->getLEDCount(channelIndex);
+		for (uint8_t fanIndex = 0; fanIndex < count / 16; fanIndex++) {
 			for (uint8_t ledIndex = 0; ledIndex < 8; ledIndex++) {
 				CRGB temp = leds[fanIndex * 16 + ledIndex];
 				leds[fanIndex * 16 + ledIndex] = leds[fanIndex * 16 + 15 - ledIndex];
@@ -104,5 +105,18 @@ void CLP::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
 		leds[ledIndex].r = dim8_video(leds[ledIndex].r);
 		leds[ledIndex].g = dim8_video(leds[ledIndex].g);
 		leds[ledIndex].b = dim8_video(leds[ledIndex].b);
+	}
+}
+
+void CLP::fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex) {
+	auto& channel = controller->getChannel(channelIndex);
+	if (channel.mode == ChannelMode::SoftwarePlayback) {
+		auto leds = controller->getLEDs(channelIndex);
+		auto count = controller->getLEDCount(channelIndex);
+		for (int ledIndex = 0; ledIndex < count; ledIndex++) {
+			leds[ledIndex].r = leds[ledIndex].r * 2;
+			leds[ledIndex].g = leds[ledIndex].g * 2;
+			leds[ledIndex].b = leds[ledIndex].b * 2;
+		}
 	}
 }

--- a/src/FastLEDControllerUtils.h
+++ b/src/FastLEDControllerUtils.h
@@ -89,4 +89,13 @@ void reverse(FastLEDController* controller, uint8_t channelIndex);
  * @param channelIndex the index of the channel
  */
 void gammaCorrection(FastLEDController* controller, uint8_t channelIndex);
+
+/**
+ * Increase the brightness of a LED channel when using iCUE Software lighting, because iCUE only send the RGB value in
+ * the range (0 - 127) which is only 50% of max possible brightness. This function doubles the received RGB value.
+ *
+ * @param controller the FastLEDController controlling the LEDs
+ * @param channelIndex the index of the channel
+ */
+void fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex);
 }  // namespace CLP


### PR DESCRIPTION
The function `fixIcueBrightness` doubles the received RGB values so they are in the range (0 - 254) close #142

TODO:
- [x] add this to readme