### PR TITLE
Update response size from 64 bytes to 16 bytes

### DIFF
--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
@@ -48,7 +48,7 @@ bool waitForSynchronization() {
 }
 
 void CLPUSBSerialBridge::sendError() {
-	memset(rawHIDAndSerialBuffer, 0, RESPONSE_SIZE);
+	memset(rawHIDAndSerialBuffer, 0, RESPONSE_SIZE_16U2);
 	rawHIDAndSerialBuffer[0] = PROTOCOL_RESPONSE_ERROR;
 	sendResponse();
 }
@@ -58,7 +58,7 @@ void CLPUSBSerialBridge::sendResponse() {
 	Serial.print(F("R"));
 	Serial.println(rawHIDAndSerialBuffer[0], HEX);
 #endif  // DEBUG
-	CLP::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE);
+	CLP::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE_16U2);
 	// free the shared buffer to receive new data
 	CLP::RawHID.enable();
 }
@@ -68,6 +68,7 @@ void CLPUSBSerialBridge::handleHID() {
 #ifdef DEBUG
 		Serial.print(F("C"));
 		Serial.println(rawHIDAndSerialBuffer[0], HEX);
+		long time = micros();
 #endif  // DEBUG
 		if (!waitForSynchronization()) {
 #ifdef DEBUG
@@ -90,5 +91,11 @@ void CLPUSBSerialBridge::handleHID() {
 			return;
 		}
 		sendResponse();
+
+#ifdef DEBUG
+		long duration = micros() - time;
+		Serial.print(F("D"));
+		Serial.println(duration);
+#endif  // DEBUG
 	}
 }

--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
@@ -48,7 +48,7 @@ bool waitForSynchronization() {
 }
 
 void CLPUSBSerialBridge::sendError() {
-	memset(rawHIDAndSerialBuffer, 0, sizeof(rawHIDAndSerialBuffer));
+	memset(rawHIDAndSerialBuffer, 0, RESPONSE_SIZE);
 	rawHIDAndSerialBuffer[0] = PROTOCOL_RESPONSE_ERROR;
 	sendResponse();
 }
@@ -58,7 +58,7 @@ void CLPUSBSerialBridge::sendResponse() {
 	Serial.print(F("R"));
 	Serial.println(rawHIDAndSerialBuffer[0], HEX);
 #endif  // DEBUG
-	CLP::RawHID.write(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
+	CLP::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE);
 	// free the shared buffer to receive new data
 	CLP::RawHID.enable();
 }
@@ -77,10 +77,10 @@ void CLPUSBSerialBridge::handleHID() {
 			return;
 		}
 
-		Serial1.write(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
+		Serial1.write(rawHIDAndSerialBuffer, COMMAND_SIZE);
 		Serial1.setTimeout(SERIAL_RESPONSE_TIMEOUT);
-		size_t read = Serial1.readBytes(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
-		if (read != sizeof(rawHIDAndSerialBuffer)) {
+		size_t read = Serial1.readBytes(rawHIDAndSerialBuffer, RESPONSE_SIZE);
+		if (read != RESPONSE_SIZE) {
 #ifdef DEBUG
 			Serial.print(F("T"));
 			Serial.println(read);

--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.h
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.h
@@ -19,7 +19,7 @@
 
 #include "Arduino.h"
 
-#if (COMMAND_SIZE == RESPONSE_SIZE)
+#if (COMMAND_SIZE >= RESPONSE_SIZE)
 #define RAWHID_AND_SERIAL_BUFFER_SIZE COMMAND_SIZE
 #endif
 

--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.h
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.h
@@ -23,6 +23,9 @@
 #define RAWHID_AND_SERIAL_BUFFER_SIZE COMMAND_SIZE
 #endif
 
+// Workaround for 16 byte responses don't work on 16U2 see https://github.com/Legion2/CorsairLightingProtocol/pull/152
+#define RESPONSE_SIZE_16U2 64
+
 #define SERIAL_SYNCHRONIZATION_TIMEOUT 20
 #define SERIAL_RESPONSE_TIMEOUT 10
 #define SERIAL_BAUD 1000000

--- a/src/CorsairLightingProtocolConstants.h
+++ b/src/CorsairLightingProtocolConstants.h
@@ -18,7 +18,7 @@
 #include "Arduino.h"
 
 #define COMMAND_SIZE 64
-#define RESPONSE_SIZE 64
+#define RESPONSE_SIZE 16
 
 #define READ_STATUS 0x01
 #define READ_FIRMWARE_VERSION 0x02

--- a/src/CorsairLightingProtocolHID.cpp
+++ b/src/CorsairLightingProtocolHID.cpp
@@ -17,10 +17,6 @@
 
 #if defined(SUPPORT_RAW_HID)
 
-#if (RAWHID_TX_SIZE != RESPONSE_SIZE)
-#error "USB endpoint must be the same size as the protocol response"
-#endif
-
 #if defined(DEBUG) && defined(VERBOSE)
 bool printCommand = PRINT_COMMAND;
 bool printResponse = PRINT_RESPONSE;

--- a/src/RawHID.h
+++ b/src/RawHID.h
@@ -42,7 +42,11 @@ THE SOFTWARE.
 #undef RAWHID_USAGE
 #define RAWHID_USAGE 0x0C00  // recommended: 0x0100 to 0xFFFF
 
+#if defined(__AVR_ATmega16U2__)
+#define RAWHID_TX_SIZE 64
+#else
 #define RAWHID_TX_SIZE 16
+#endif
 #define RAWHID_RX_SIZE 64
 
 #endif
@@ -51,7 +55,7 @@ THE SOFTWARE.
 
 #define EPTYPE_DESCRIPTOR_SIZE uint8_t
 // HID Functional Characteristics HID1.11 Page 10 4.4 Interfaces
-// Interrupt Out Endpoint is optional, contoll endpoint is used by default
+// Interrupt Out Endpoint is optional, control endpoint is used by default
 #define ENDPOINT_COUNT 1
 namespace CLP {
 class RawHID_ : public PluggableUSBModule, public Stream {

--- a/src/RawHID.h
+++ b/src/RawHID.h
@@ -42,7 +42,7 @@ THE SOFTWARE.
 #undef RAWHID_USAGE
 #define RAWHID_USAGE 0x0C00  // recommended: 0x0100 to 0xFFFF
 
-#define RAWHID_TX_SIZE 64
+#define RAWHID_TX_SIZE 16
 #define RAWHID_RX_SIZE 64
 
 #endif


### PR DESCRIPTION
This matches what I've found reverse engineering the Corsair Lighting Node Pro/Commander Pro and has been documented in the OpenCorsairLink issue below.  I have tested that this fixes compatibility with OpenRGB (after the latest commit, which adds the 16-byte reads) and maintains compatibility with iCue.

References:

https://gitlab.com/CalcProgrammer1/OpenRGB/-/wikis/Corsair-Lighting-Node-Devices

https://github.com/audiohacked/OpenCorsairLink/issues/70