### PR TITLE
Use CorsairLightingProtocol namespace and naming convention

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 You can contribute in many different ways, for example report a bug or come up with an idea for improvement.
 If you are good at programming you could also provide a fix for bugs or Pull Requests with improvements.
-If you want to help others using CLP you are welcome to extend the [Wiki on GitHub](https://github.com/Legion2/CorsairLightingProtocol/wiki).
+If you want to help others using CorsairLightingProtocol (CLP) you are welcome to extend the [Wiki on GitHub](https://github.com/Legion2/CorsairLightingProtocol/wiki).
 
 ## Finding information
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,3 +32,13 @@ Public methods must be documented with JavaDoc style comments.
 When introducing new methods you should think about if the method should be part of the public API or only used internally.
 Always use descriptive names for variables, only use acronyms if they are well known and frequently used.
 The coding style is defined using ClangFormat and automatically checked when you submit a Pull Request.
+
+### Naming
+
+Everything should be defined in the `CorsairLightingProtocol` namespace.
+Use camel case for names.
+Type names start with an upper case letter and variable, parameter and property names start with a lower case letter.
+
+Free function names should be unambiguous without the namespace.
+So, don't use names such as `reset` or `init`.
+Instead use `resetSomething` or `initSomethingElse`.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ You can repeat or scale LED channel controlled by iCUE onto physical LED strips.
 This is very useful if you have very long LED strips that are longer than 60/96/135 LEDs.
 This is the maximum number iCUE supports.
 
-To repeat or scale a LED channel you must apply the `CLP::repeat` or the `CLP:scale` function in the update hook of the FastLEDController.
+To repeat or scale a LED channel you must apply the `CorsairLightingProtocol::repeat` or the `CorsairLightingProtocol::scale` function in the update hook of the FastLEDController.
 See the [RepeatAndScale](examples/RepeatAndScale/RepeatAndScale.ino) example for the complete code.
 Both functions take the FastLEDController pointer and the channel index as arguments.
 Additionally, the `repeat` function takes as an argument how often the LED channel should be repeated.
@@ -148,11 +148,11 @@ This means if your LED channel from iCUE has 50 LEDs and you use the `repeat` fu
 ## Increase the Brightness of the LEDs
 By default iCUE only uses 50% of the LEDs brightness even if you set the brightness to max in the iCUE Device Settings.
 But there are good news, we can increase the brightness with the Arduino so we can use the full brightness of our LEDs.
-Add the `CLP::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AdditionalFeatures/AdditionalFeatures.ino).
+Add the `CorsairLightingProtocol::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AdditionalFeatures/AdditionalFeatures.ino).
 If there are multiple functions called in `onUpdateHook`, `fixIcueBrightness` should be the first.
 ```C++
 ledController.onUpdateHook(0, []() {
-	CLP::fixIcueBrightness(&ledController, 0);
+	CorsairLightingProtocol::fixIcueBrightness(&ledController, 0);
 });
 ```
 

--- a/examples/AdditionalFeatures/AdditionalFeatures.ino
+++ b/examples/AdditionalFeatures/AdditionalFeatures.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
@@ -33,11 +34,11 @@ CorsairLightingProtocolHID cHID(&cLP, mySerialNumber);
 
 void setup() {
 	// Disable the build in RX and TX LEDs of the Arduino
-	CLP::disableBuildInLEDs();
+	disableBuildInLEDs();
 	// enable reset on DeviceId (FF FF FF FF)
-	if (CLP::shouldReset(&firmware)) {
+	if (shouldReset(&firmware)) {
 		// reset DeviceId and generate new one
-		CLP::reset(&firmware);
+		reset(&firmware);
 		// reset the LEDController Settings
 		ledController.reset();
 	}
@@ -49,7 +50,7 @@ void setup() {
 	// modify the RGB values before they are shown on the LED strip
 	ledController.onUpdateHook(0, []() {
 		// increase the brightness of channel 1 when using iCUE, because iCUE only set brightness to max 50%
-		CLP::fixIcueBrightness(&ledController, 0);
+		fixIcueBrightness(&ledController, 0);
 	});
 }
 

--- a/examples/AmbientBacklight/AmbientBacklight.ino
+++ b/examples/AmbientBacklight/AmbientBacklight.ino
@@ -35,7 +35,7 @@ void setup() {
 	ledController.addLEDs(1, ledsChannel2, 105);
 	ledController.onUpdateHook(0, []() {
 		// gamma correction with gamma value 2.0. Use napplyGamma_video for other gamma values.
-		CLP::gammaCorrection(&ledController, 0);
+		CorsairLightingProtocol::gammaCorrection(&ledController, 0);
 		// napplyGamma_video(ledsChannel1, 84, 2.2);
 	});
 }

--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -50,7 +50,7 @@ PWMFan fan3(PWM_FAN_PIN_3, 0, 2000);
 PWMFan fan4(PWM_FAN_PIN_4, 0, 2000);
 
 void setup() {
-	CLP::disableBuildInLEDs();
+	CorsairLightingProtocol::disableBuildInLEDs();
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_1, GRB>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_2, GRB>(ledsChannel2, CHANNEL_LED_COUNT);
 	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);

--- a/examples/DebugSketch/DebugSketch.ino
+++ b/examples/DebugSketch/DebugSketch.ino
@@ -61,7 +61,7 @@ void processCommand(String& cmd) {
 	if (cmd == F("print DeviceID")) {
 		byte deviceId[4];
 		firmware.getDeviceID(deviceId);
-		CLP::printDeviceID(deviceId);
+		CorsairLightingProtocol::printDeviceID(deviceId);
 		Serial.println();
 	}
 #ifdef VERBOSE

--- a/examples/DeviceIDTool/DeviceIDTool.ino
+++ b/examples/DeviceIDTool/DeviceIDTool.ino
@@ -31,7 +31,7 @@ void setup() {
 		;  // wait for serial port to connect. Needed for native USB
 	}
 	Serial.print(F("Current DeviceID: "));
-	CLP::printDeviceID(deviceID);
+	CorsairLightingProtocol::printDeviceID(deviceID);
 	Serial.println();
 	Serial.println(
 		F("Set a new DeviceID by typing it in the Serial Monitor. The new DeviceID must be in same format as above. 4 "
@@ -54,14 +54,14 @@ void loop() {
 			newDeviceID[2] = strtol(&inputString[6], nullptr, 16);
 			newDeviceID[3] = strtol(&inputString[9], nullptr, 16);
 			Serial.println(F("Set DeviceID to: "));
-			CLP::printDeviceID(newDeviceID);
+			CorsairLightingProtocol::printDeviceID(newDeviceID);
 			Serial.println();
-			if (CLP::isNullID(newDeviceID)) {
+			if (CorsairLightingProtocol::isNullID(newDeviceID)) {
 				Serial.println(
 					F("This is a special DeviceID, it will generate a new random DeviceID next time iCUE controls the "
 					  "device!"));
 			}
-			if (CLP::isResetID(newDeviceID)) {
+			if (CorsairLightingProtocol::isResetID(newDeviceID)) {
 				Serial.println(
 					F("This is a special DeviceID, it will reset the device and then generate a new DeviceID!"));
 			}

--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
@@ -29,12 +29,12 @@ void resetIOMCU() {
 }
 
 CLPUSBSerialBridge::CLPUSBSerialBridge(const char* serialNumber) {
-	CLP::RawHID.setSerialNumber(serialNumber);
+	CorsairLightingProtocol::RawHID.setSerialNumber(serialNumber);
 }
 
 void CLPUSBSerialBridge::begin() {
 	Serial1.begin(SERIAL_BAUD);
-	CLP::RawHID.begin(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
+	CorsairLightingProtocol::RawHID.begin(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
 }
 
 bool waitForSynchronization() {
@@ -58,13 +58,13 @@ void CLPUSBSerialBridge::sendResponse() {
 	Serial.print(F("R"));
 	Serial.println(rawHIDAndSerialBuffer[0], HEX);
 #endif  // DEBUG
-	CLP::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE_16U2);
+	CorsairLightingProtocol::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE_16U2);
 	// free the shared buffer to receive new data
-	CLP::RawHID.enable();
+	CorsairLightingProtocol::RawHID.enable();
 }
 
 void CLPUSBSerialBridge::handleHID() {
-	if (CLP::RawHID.available()) {
+	if (CorsairLightingProtocol::RawHID.available()) {
 #ifdef DEBUG
 		Serial.print(F("C"));
 		Serial.println(rawHIDAndSerialBuffer[0], HEX);

--- a/examples/RepeatAndScale/RepeatAndScale.ino
+++ b/examples/RepeatAndScale/RepeatAndScale.ino
@@ -33,10 +33,10 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 50);
 	ledController.addLEDs(1, ledsChannel2, 60);
 	ledController.onUpdateHook(0, []() {
-		CLP::repeat(&ledController, 0, 2);
+		CorsairLightingProtocol::repeat(&ledController, 0, 2);
 	});
 	ledController.onUpdateHook(1, []() {
-		CLP::scale(&ledController, 1, 144);
+		CorsairLightingProtocol::scale(&ledController, 1, 144);
 	});
 }
 

--- a/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
+++ b/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
@@ -39,7 +39,7 @@ void setup() {
 #ifdef DEBUG
 	Serial.begin(115200);
 #endif
-	CLP::disableBuildInLEDs();
+	CorsairLightingProtocol::disableBuildInLEDs();
 	FastLED.addLeds<WS2812B, DATA_PIN, GRB>(leds, NUM_LEDS);
 	ledController.addLEDs(0, leds, CHANNEL_LED_COUNT);
 	ledController.addLEDs(1, &(leds[CHANNEL_LED_COUNT]), CHANNEL_LED_COUNT);

--- a/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
+++ b/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
@@ -33,7 +33,7 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 96);
 	ledController.addLEDs(1, ledsChannel2, 60);
 	ledController.onUpdateHook(0, []() {
-		CLP::transformLLFanToStrip(&ledController, 0);
+		CorsairLightingProtocol::transformLLFanToStrip(&ledController, 0);
 	});
 }
 

--- a/examples/UnitTests/UnitTests.ino
+++ b/examples/UnitTests/UnitTests.ino
@@ -45,7 +45,7 @@ testF(FastLEDControllerTest, simpleScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::scale(&ledController, 0, 20);
+	CorsairLightingProtocol::scale(&ledController, 0, 20);
 
 	for (int i = 0; i < 10; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -59,7 +59,7 @@ testF(FastLEDControllerTest, simpleScaleDown) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::scale(&ledController, 0, 10);
+	CorsairLightingProtocol::scale(&ledController, 0, 10);
 
 	for (int i = 0; i < 5; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -76,7 +76,7 @@ testF(FastLEDControllerTest, simpleScaleIdentity) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::scale(&ledController, 0, 10);
+	CorsairLightingProtocol::scale(&ledController, 0, 10);
 
 	for (int i = 0; i < 10; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -94,8 +94,8 @@ testF(FastLEDControllerTest, LT100) {
 
 	leds[0] = CRGB::White;
 	fill_solid(leds + 1, 26, CRGB::Blue);
-	CLP::SegmentScaling segments[2] = {{1, 4}, {26, 26}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[2] = {{1, 4}, {26, 26}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	for (int i = 0; i < 4; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -112,8 +112,8 @@ testF(FastLEDControllerTest, singleSegmentScaleUp) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::SegmentScaling segments[] = {{10, 20}};
-	CLP::scaleSegments(&ledController, 0, segments, 1);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 20}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
 
 	for (int i = 0; i < 20; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -127,8 +127,8 @@ testF(FastLEDControllerTest, multiScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds + 5, 5, CRGB::White);
-	CLP::SegmentScaling segments[] = {{5, 10}, {5, 20}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {5, 20}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	for (int i = 0; i < 10; i++) {
 		assertCRGB(leds[i], CRGB::Black);
@@ -145,8 +145,8 @@ testF(FastLEDControllerTest, multiScaleDown) {
 	ledController.addLEDs(0, leds, 30);
 
 	fill_solid(leds + 10, 20, CRGB::White);
-	CLP::SegmentScaling segments[] = {{10, 5}, {20, 5}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {20, 5}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	for (int i = 0; i < 5; i++) {
 		assertCRGB(leds[i], CRGB::Black);
@@ -163,8 +163,8 @@ testF(FastLEDControllerTest, singleSegmentScaleDown) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::SegmentScaling segments[] = {{20, 10}};
-	CLP::scaleSegments(&ledController, 0, segments, 1);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{20, 10}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
 
 	for (int i = 0; i < 5; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -181,8 +181,8 @@ testF(FastLEDControllerTest, SegmentScaleOverlap) {
 	ledController.addLEDs(0, leds, 15);
 
 	fill_solid(leds, 5, CRGB::White);
-	CLP::SegmentScaling segments[] = {{5, 10}, {10, 5}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {10, 5}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	for (int i = 0; i < 10; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -199,8 +199,8 @@ testF(FastLEDControllerTest, SegmentScaleOverlapInverted) {
 	ledController.addLEDs(0, leds, 15);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::SegmentScaling segments[] = {{10, 5}, {5, 10}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {5, 10}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	for (int i = 0; i < 5; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -219,8 +219,8 @@ testF(FastLEDControllerTest, SegmentScaleMix) {
 	fill_solid(leds, 5, CRGB::White);
 	fill_solid(leds + 5, 20, CRGB::Red);
 	fill_solid(leds + 25, 5, CRGB::Blue);
-	CLP::SegmentScaling segments[] = {{5, 10}, {20, 5}, {5, 10}};
-	CLP::scaleSegments(&ledController, 0, segments, 3);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {20, 5}, {5, 10}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 3);
 
 	for (int i = 0; i < 10; i++) {
 		assertCRGB(leds[i], CRGB::White);
@@ -242,8 +242,8 @@ testF(FastLEDControllerTest, SegmentScaleMixInverted) {
 	fill_solid(leds, 10, CRGB::White);
 	fill_solid(leds + 10, 5, CRGB::Red);
 	fill_solid(leds + 15, 10, CRGB::Blue);
-	CLP::SegmentScaling segments[] = {{10, 5}, {5, 20}, {10, 5}};
-	CLP::scaleSegments(&ledController, 0, segments, 3);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {5, 20}, {10, 5}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 3);
 
 	for (int i = 0; i < 5; i++) {
 		assertCRGB(leds[i], CRGB::White);

--- a/src/CLPAdditionalFeatures.cpp
+++ b/src/CLPAdditionalFeatures.cpp
@@ -17,13 +17,13 @@
 
 #include "CLPUtils.h"
 
-bool CLP::shouldReset(const CorsairLightingFirmware* firmware) {
+bool CorsairLightingProtocol::shouldReset(const CorsairLightingFirmware* firmware) {
 	byte deviceId[4];
 	firmware->getDeviceID(deviceId);
-	return CLP::isResetID(deviceId);
+	return CorsairLightingProtocol::isResetID(deviceId);
 }
 
-void CLP::reset(CorsairLightingFirmware* firmware) {
+void CorsairLightingProtocol::reset(CorsairLightingFirmware* firmware) {
 	byte deviceId[4] = {0x00};
 	firmware->setDeviceID(deviceId);
 }

--- a/src/CLPAdditionalFeatures.h
+++ b/src/CLPAdditionalFeatures.h
@@ -18,7 +18,7 @@
 #include "Arduino.h"
 #include "CorsairLightingFirmware.h"
 
-namespace CLP {
+namespace CorsairLightingProtocol {
 /**
  * Check if the device should be reseted. The check is based on the DeviceID from the firmware.
  *
@@ -33,4 +33,4 @@ bool shouldReset(const CorsairLightingFirmware* firmware);
  * @param firmware reset this firmware
  */
 void reset(CorsairLightingFirmware* firmware);
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol

--- a/src/CLPUtils.cpp
+++ b/src/CLPUtils.cpp
@@ -15,14 +15,14 @@
 */
 #include "CLPUtils.h"
 
-uint16_t CLP::fromBigEndian(const byte& byte1, const byte& byte2) {
+uint16_t CorsairLightingProtocol::fromBigEndian(const byte& byte1, const byte& byte2) {
 	uint16_t t = byte1;
 	t = t << 8;
 	t |= byte2;
 	return t;
 }
 
-void CLP::disableBuildInLEDs() {
+void CorsairLightingProtocol::disableBuildInLEDs() {
 #ifndef DEBUG
 #ifdef LED_BUILTIN_RX
 	pinMode(LED_BUILTIN_RX, INPUT);
@@ -33,13 +33,15 @@ void CLP::disableBuildInLEDs() {
 #endif
 }
 
-bool CLP::isNullID(const uint8_t* deviceId) { return !(deviceId[0] | deviceId[1] | deviceId[2] | deviceId[3]); }
+bool CorsairLightingProtocol::isNullID(const uint8_t* deviceId) {
+	return !(deviceId[0] | deviceId[1] | deviceId[2] | deviceId[3]);
+}
 
-bool CLP::isResetID(const uint8_t* deviceId) {
+bool CorsairLightingProtocol::isResetID(const uint8_t* deviceId) {
 	return deviceId[0] == 0xFF && deviceId[1] == 0xFF && deviceId[2] == 0xFF && deviceId[3] == 0xFF;
 }
 
-void CLP::printDeviceID(const uint8_t* deviceId) {
+void CorsairLightingProtocol::printDeviceID(const uint8_t* deviceId) {
 	char tmp[16];
 	for (size_t i = 0; i < 4; i++) {
 		sprintf(tmp, "%.2X", deviceId[i]);

--- a/src/CLPUtils.h
+++ b/src/CLPUtils.h
@@ -19,7 +19,7 @@
 
 #define toBigEndian(a) highByte(a), lowByte(a)
 
-namespace CLP {
+namespace CorsairLightingProtocol {
 uint16_t fromBigEndian(const byte& byte1, const byte& byte2);
 
 /**
@@ -61,4 +61,4 @@ void disableBuildInLEDs();
  * @param deviceId the device id to print
  */
 void printDeviceID(const uint8_t* deviceId);
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol

--- a/src/CorsairLightingProtocolHID.cpp
+++ b/src/CorsairLightingProtocolHID.cpp
@@ -24,13 +24,13 @@ bool printResponse = PRINT_RESPONSE;
 
 CorsairLightingProtocolHID::CorsairLightingProtocolHID(CorsairLightingProtocolController* controller)
 	: controller(controller) {
-	CLP::RawHID.begin(rawhidData, sizeof(rawhidData));
+	CorsairLightingProtocol::RawHID.begin(rawhidData, sizeof(rawhidData));
 }
 
 CorsairLightingProtocolHID::CorsairLightingProtocolHID(CorsairLightingProtocolController* controller,
 													   const char* serialNumber)
 	: CorsairLightingProtocolHID(controller) {
-	CLP::RawHID.setSerialNumber(serialNumber);
+	CorsairLightingProtocol::RawHID.setSerialNumber(serialNumber);
 }
 
 void CorsairLightingProtocolHID::update() {
@@ -41,12 +41,12 @@ void CorsairLightingProtocolHID::update() {
 	}
 }
 
-bool CorsairLightingProtocolHID::available() const { return CLP::RawHID.available() > 0; }
+bool CorsairLightingProtocolHID::available() const { return CorsairLightingProtocol::RawHID.available() > 0; }
 
 void CorsairLightingProtocolHID::getCommand(Command& command) {
-	auto bytesAvailable = CLP::RawHID.available();
+	auto bytesAvailable = CorsairLightingProtocol::RawHID.available();
 	if (bytesAvailable) {
-		CLP::RawHID.readBytes(command.raw, sizeof(command.raw));
+		CorsairLightingProtocol::RawHID.readBytes(command.raw, sizeof(command.raw));
 #if defined(DEBUG) && defined(VERBOSE)
 		if (printCommand) {
 			Serial.print(F("Received Command: "));
@@ -65,7 +65,7 @@ void CorsairLightingProtocolHID::sendX(const uint8_t* data, const size_t x) cons
 		Serial.println(data[0], HEX);
 	}
 #endif
-	CLP::RawHID.write(data, x);
+	CorsairLightingProtocol::RawHID.write(data, x);
 }
 
 #endif

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -67,7 +67,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				return;
 			}
 			uint8_t power = getFanPower(fan);
-			uint8_t powerData[] = {CLP::convert255To100(power)};
+			uint8_t powerData[] = {CorsairLightingProtocol::convert255To100(power)};
 			response->send(powerData, sizeof(powerData));
 			break;
 		}
@@ -77,7 +77,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				response->sendError();
 				return;
 			}
-			uint8_t percentage = CLP::convert100To255(command.data[1]);
+			uint8_t percentage = CorsairLightingProtocol::convert100To255(command.data[1]);
 			setFanPower(fan, percentage);
 			response->send(nullptr, 0);
 			break;
@@ -88,7 +88,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				response->sendError();
 				return;
 			}
-			uint16_t speed = CLP::fromBigEndian(command.data[1], command.data[2]);
+			uint16_t speed = CorsairLightingProtocol::fromBigEndian(command.data[1], command.data[2]);
 			setFanSpeed(fan, speed);
 			response->send(nullptr, 0);
 			break;
@@ -102,8 +102,10 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 			const uint8_t& group = command.data[1];
 			FanCurve fanCurve;
 			for (uint8_t i = 0; i < FAN_CURVE_POINTS_NUM; i++) {
-				fanCurve.temperatures[i] = CLP::fromBigEndian(command.data[2 + i * 2], command.data[3 + i * 2]);
-				fanCurve.rpms[i] = CLP::fromBigEndian(command.data[14 + i * 2], command.data[15 + i * 2]);
+				fanCurve.temperatures[i] =
+					CorsairLightingProtocol::fromBigEndian(command.data[2 + i * 2], command.data[3 + i * 2]);
+				fanCurve.rpms[i] =
+					CorsairLightingProtocol::fromBigEndian(command.data[14 + i * 2], command.data[15 + i * 2]);
 			}
 			setFanCurve(fan, group, fanCurve);
 			response->send(nullptr, 0);
@@ -115,7 +117,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				response->sendError();
 				return;
 			}
-			uint16_t temp = CLP::fromBigEndian(command.data[1], command.data[2]);
+			uint16_t temp = CorsairLightingProtocol::fromBigEndian(command.data[1], command.data[2]);
 			setFanExternalTemperature(fan, temp);
 			response->send(nullptr, 0);
 			break;

--- a/src/FastLEDControllerUtils.cpp
+++ b/src/FastLEDControllerUtils.cpp
@@ -18,7 +18,7 @@
 #include <FastLED.h>
 #include <math.h>
 
-void CLP::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIndex) {
 	auto& channel = controller->getChannel(channelIndex);
 	if (channel.mode == ChannelMode::SoftwarePlayback) {
 		auto leds = controller->getLEDs(channelIndex);
@@ -44,7 +44,7 @@ void CLP::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIn
  */
 int scaleIndexAsPosition(int index, const float scaleFactor) { return ceil((index + 1) * scaleFactor) - 1; }
 
-void CLP::scale(FastLEDController* controller, uint8_t channelIndex, int scaleToSize) {
+void CorsairLightingProtocol::scale(FastLEDController* controller, uint8_t channelIndex, int scaleToSize) {
 	auto leds = controller->getLEDs(channelIndex);
 	const float scaleFactor = (float)controller->getLEDCount(channelIndex) / scaleToSize;
 	if (scaleFactor < 1.0f) {
@@ -58,7 +58,7 @@ void CLP::scale(FastLEDController* controller, uint8_t channelIndex, int scaleTo
 	}
 }
 
-void CLP::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t times) {
+void CorsairLightingProtocol::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t times) {
 	auto leds = controller->getLEDs(channelIndex);
 	auto count = controller->getLEDCount(channelIndex);
 	// skip first iteration, because LEDs already contains the data at the first position
@@ -67,8 +67,8 @@ void CLP::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t ti
 	}
 }
 
-void CLP::scaleSegments(FastLEDController* controller, uint8_t channelIndex, const SegmentScaling* const segments,
-						int segmentsCount) {
+void CorsairLightingProtocol::scaleSegments(FastLEDController* controller, uint8_t channelIndex,
+											const SegmentScaling* const segments, int segmentsCount) {
 	auto leds = controller->getLEDs(channelIndex);
 	int ledStripIndexAfterScaling = 0;
 	int ledStripIndexBeforeScaling = 0;
@@ -105,7 +105,7 @@ void CLP::scaleSegments(FastLEDController* controller, uint8_t channelIndex, con
 	}
 }
 
-void CLP::reverse(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::reverse(FastLEDController* controller, uint8_t channelIndex) {
 	auto leds = controller->getLEDs(channelIndex);
 	auto maxIndex = controller->getLEDCount(channelIndex) - 1;
 	for (int ledIndex = 0; ledIndex < maxIndex - ledIndex; ledIndex++) {
@@ -115,7 +115,7 @@ void CLP::reverse(FastLEDController* controller, uint8_t channelIndex) {
 	}
 }
 
-void CLP::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
 	auto leds = controller->getLEDs(channelIndex);
 	auto count = controller->getLEDCount(channelIndex);
 	for (int ledIndex = 0; ledIndex < count; ledIndex++) {
@@ -125,7 +125,7 @@ void CLP::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
 	}
 }
 
-void CLP::fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex) {
 	auto& channel = controller->getChannel(channelIndex);
 	if (channel.mode == ChannelMode::SoftwarePlayback) {
 		auto leds = controller->getLEDs(channelIndex);

--- a/src/FastLEDControllerUtils.h
+++ b/src/FastLEDControllerUtils.h
@@ -18,7 +18,7 @@
 #include "Arduino.h"
 #include "FastLEDController.h"
 
-namespace CLP {
+namespace CorsairLightingProtocol {
 /**
  * Make it possible to use up to 96 LEDs per channel from iCUE by using the LL Fan option. This function transforms the
  * LL fans layout to a normal strip layout. This function can be combined with scale and repeat function but must be
@@ -98,4 +98,4 @@ void gammaCorrection(FastLEDController* controller, uint8_t channelIndex);
  * @param channelIndex the index of the channel
  */
 void fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex);
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol

--- a/src/LEDController.cpp
+++ b/src/LEDController.cpp
@@ -90,9 +90,9 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 				group.color3.r = data[14];
 				group.color3.g = data[15];
 				group.color3.b = data[16];
-				group.temp1 = CLP::fromBigEndian(data[17], data[18]);
-				group.temp2 = CLP::fromBigEndian(data[19], data[20]);
-				group.temp3 = CLP::fromBigEndian(data[21], data[22]);
+				group.temp1 = CorsairLightingProtocol::fromBigEndian(data[17], data[18]);
+				group.temp2 = CorsairLightingProtocol::fromBigEndian(data[19], data[20]);
+				group.temp3 = CorsairLightingProtocol::fromBigEndian(data[21], data[22]);
 
 				if (!isValidLEDGroup(group)) {
 					response->sendError();
@@ -103,7 +103,7 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 				break;
 			}
 			case WRITE_LED_EXTERNAL_TEMP: {
-				setLEDExternalTemperature(channel, CLP::fromBigEndian(data[2], data[3]));
+				setLEDExternalTemperature(channel, CorsairLightingProtocol::fromBigEndian(data[2], data[3]));
 				break;
 			}
 			case WRITE_LED_GROUPS_CLEAR: {
@@ -126,7 +126,7 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 				break;
 			}
 			case WRITE_LED_BRIGHTNESS: {
-				uint8_t brightness = CLP::convert100To255(data[1]);
+				uint8_t brightness = CorsairLightingProtocol::convert100To255(data[1]);
 				triggerSave |= setLEDBrightness(channel, brightness);
 				break;
 			}

--- a/src/RawHID.cpp
+++ b/src/RawHID.cpp
@@ -55,7 +55,7 @@ static const uint8_t  _hidReportDescriptorRawHID[] PROGMEM = {
 
 const char defaultSerialNumber[] PROGMEM = SERIAL_NUMBER;
 
-CLP::RawHID_::RawHID_(void)
+CorsairLightingProtocol::RawHID_::RawHID_(void)
 	: PluggableUSBModule(ENDPOINT_COUNT, 1, epType),
 	  protocol(HID_REPORT_PROTOCOL),
 	  idle(1),
@@ -70,9 +70,9 @@ CLP::RawHID_::RawHID_(void)
 	PluggableUSB().plug(this);
 }
 
-void CLP::RawHID_::setSerialNumber(const char* argSerialNumber) { serialNumber = argSerialNumber; }
+void CorsairLightingProtocol::RawHID_::setSerialNumber(const char* argSerialNumber) { serialNumber = argSerialNumber; }
 
-int CLP::RawHID_::getInterface(uint8_t* interfaceCount) {
+int CorsairLightingProtocol::RawHID_::getInterface(uint8_t* interfaceCount) {
 	// Maybe as optional device FastRawHID with different USAGE PAGE
 	*interfaceCount += 1;  // uses 1
 	HIDDescriptor hidInterface = {D_INTERFACE(pluggedInterface, ENDPOINT_COUNT, USB_DEVICE_CLASS_HUMAN_INTERFACE,
@@ -83,7 +83,7 @@ int CLP::RawHID_::getInterface(uint8_t* interfaceCount) {
 	return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
-int CLP::RawHID_::getDescriptor(USBSetup& setup) {
+int CorsairLightingProtocol::RawHID_::getDescriptor(USBSetup& setup) {
 	// Check if this is a HID Class Descriptor request
 	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
 		return 0;
@@ -104,7 +104,7 @@ int CLP::RawHID_::getDescriptor(USBSetup& setup) {
 	return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorRawHID, sizeof(_hidReportDescriptorRawHID));
 }
 
-bool CLP::RawHID_::setup(USBSetup& setup) {
+bool CorsairLightingProtocol::RawHID_::setup(USBSetup& setup) {
 	if (pluggedInterface != setup.wIndex) {
 		return false;
 	}
@@ -165,12 +165,12 @@ bool CLP::RawHID_::setup(USBSetup& setup) {
 	return false;
 }
 
-uint8_t CLP::RawHID_::getShortName(char* name) {
+uint8_t CorsairLightingProtocol::RawHID_::getShortName(char* name) {
 	name[0] = '\0';
 	strncat_P(name, serialNumber, ISERIAL_MAX_LEN - 1);
 	return strlen(name);
 }
-namespace CLP {
+namespace CorsairLightingProtocol {
 RawHID_ RawHID;
 }
 #endif

--- a/src/RawHID.h
+++ b/src/RawHID.h
@@ -57,7 +57,7 @@ THE SOFTWARE.
 // HID Functional Characteristics HID1.11 Page 10 4.4 Interfaces
 // Interrupt Out Endpoint is optional, control endpoint is used by default
 #define ENDPOINT_COUNT 1
-namespace CLP {
+namespace CorsairLightingProtocol {
 class RawHID_ : public PluggableUSBModule, public Stream {
 public:
 	RawHID_(void);
@@ -164,5 +164,5 @@ protected:
 	int featureLength;
 };
 extern RawHID_ RawHID;
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol
 #endif


### PR DESCRIPTION
rename existing namespace
add CorsairLightingProtocol close #168
rename some free functions

Todo:
- [ ] add CorsairLightingProtocol
- [ ] rename some free functions
- [ ] add `using namespace CorsairLightingProtocol;` to every sketch
- [ ] create migration guide