### PR TITLE
added note to fixIcueBrightness

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,11 @@ For both functions it's **important**, that the CRGB arrays have at least the le
 This means if your LED channel from iCUE has 50 LEDs and you use the `repeat` function to control 100 physical LEDs you MUST declare the CRGB array at least with a length of 100.
 
 ## Increase the Brightness of the LEDs
-By default iCUE only uses 50% of the LEDs brightness even if you set the brightness to max in the iCUE Device Settings.
+When using LS100 or LT100 iCUE only uses 50% of the LEDs brightness even if you set the brightness to max in the iCUE Device Settings.
 But there are good news, we can increase the brightness with the Arduino so we can use the full brightness of our LEDs.
-Add the `CLP::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AdditionalFeatures/AdditionalFeatures.ino).
+Add the `CLP::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AmbientBacklight/AmbientBacklight.ino).
 If there are multiple functions called in `onUpdateHook`, `fixIcueBrightness` should be the first.
+Only use this function with LS100 and LT100 devices!
 ```C++
 ledController.onUpdateHook(0, []() {
 	CLP::fixIcueBrightness(&ledController, 0);

--- a/examples/AdditionalFeatures/AdditionalFeatures.ino
+++ b/examples/AdditionalFeatures/AdditionalFeatures.ino
@@ -45,12 +45,6 @@ void setup() {
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_2, GRB>(ledsChannel2, 60);
 	ledController.addLEDs(0, ledsChannel1, 60);
 	ledController.addLEDs(1, ledsChannel2, 60);
-
-	// modify the RGB values before they are shown on the LED strip
-	ledController.onUpdateHook(0, []() {
-		// increase the brightness of channel 1 when using iCUE, because iCUE only set brightness to max 50%
-		CLP::fixIcueBrightness(&ledController, 0);
-	});
 }
 
 void loop() {

--- a/examples/AmbientBacklight/AmbientBacklight.ino
+++ b/examples/AmbientBacklight/AmbientBacklight.ino
@@ -34,6 +34,8 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 84);
 	ledController.addLEDs(1, ledsChannel2, 105);
 	ledController.onUpdateHook(0, []() {
+		// increase the brightness of channel 1 when using iCUE, because iCUE only set brightness to max 50%
+		CLP::fixIcueBrightness(&ledController, 0);
 		// gamma correction with gamma value 2.0. Use napplyGamma_video for other gamma values.
 		CLP::gammaCorrection(&ledController, 0);
 		// napplyGamma_video(ledsChannel1, 84, 2.2);

--- a/src/FastLEDControllerUtils.h
+++ b/src/FastLEDControllerUtils.h
@@ -91,8 +91,9 @@ void reverse(FastLEDController* controller, uint8_t channelIndex);
 void gammaCorrection(FastLEDController* controller, uint8_t channelIndex);
 
 /**
- * Increase the brightness of a LED channel when using iCUE Software lighting, because iCUE only send the RGB value in
- * the range (0 - 127) which is only 50% of max possible brightness. This function doubles the received RGB value.
+ * Increase the brightness of a LED channel when using LS100 and LT100 with iCUE Software lighting, because iCUE only
+ * send the RGB value in the range (0 - 127) which is only 50% of max possible brightness. This function doubles the
+ * received RGB value. Only use this function with LS100 and LT100.
  *
  * @param controller the FastLEDController controlling the LEDs
  * @param channelIndex the index of the channel


### PR DESCRIPTION
`fixIcueBrightness` should only be used with LS100 and LT100 close #175