### PR TITLE
Use CorsairLightingProtocol namespace and naming convention

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 You can contribute in many different ways, for example report a bug or come up with an idea for improvement.
 If you are good at programming you could also provide a fix for bugs or Pull Requests with improvements.
-If you want to help others using CLP you are welcome to extend the [Wiki on GitHub](https://github.com/Legion2/CorsairLightingProtocol/wiki).
+If you want to help others using CorsairLightingProtocol (CLP) you are welcome to extend the [Wiki on GitHub](https://github.com/Legion2/CorsairLightingProtocol/wiki).
 
 ## Finding information
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,3 +32,13 @@ Public methods must be documented with JavaDoc style comments.
 When introducing new methods you should think about if the method should be part of the public API or only used internally.
 Always use descriptive names for variables, only use acronyms if they are well known and frequently used.
 The coding style is defined using ClangFormat and automatically checked when you submit a Pull Request.
+
+### Naming
+
+Everything should be defined in the `CorsairLightingProtocol` namespace.
+Use camel case for names.
+Type names start with an upper case letter and variable, parameter and property names start with a lower case letter.
+
+Free function names should be unambiguous without the namespace.
+So, don't use names such as `reset` or `init`.
+Instead use `resetSomething` or `initSomethingElse`.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ After that, you can upload another sketch.
 You can repeat or scale LED channel controlled by iCUE onto physical LED strips.
 This is very useful if you have very long LED strips that are longer than 60/96/135 LEDs, which is the maximum number iCUE supports.
 
-To repeat or scale a LED channel you must apply the `CorsairLightingProtocol::repeat` or the `CorsairLightingProtocol::scale` function in the update hook of the FastLEDController.
+To repeat or scale a LED channel you must apply the `repeat` or the `scale` function in the update hook of the FastLEDController.
 See the [RepeatAndScale](examples/RepeatAndScale/RepeatAndScale.ino) example for the complete code.
 Both functions take the FastLEDController pointer and the channel index as arguments.
 Additionally, the `repeat` function takes as an argument how often the LED channel should be repeated.
@@ -149,12 +149,12 @@ This means if your LED channel from iCUE has 50 LEDs and you use the `repeat` fu
 ## Increase the Brightness of the LEDs
 When using LS100 or LT100 iCUE only uses 50% of the LEDs brightness even if you set the brightness to max in the iCUE Device Settings.
 But there are good news, we can increase the brightness with the Arduino so we can use the full brightness of our LEDs.
-Add the `CorsairLightingProtocol::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AmbientBacklight/AmbientBacklight.ino).
+Add the `fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AmbientBacklight/AmbientBacklight.ino).
 If there are multiple functions called in `onUpdateHook`, `fixIcueBrightness` should be the first.
 Only use this function with LS100 and LT100 devices!
 ```C++
 ledController.onUpdateHook(0, []() {
-	CorsairLightingProtocol::fixIcueBrightness(&ledController, 0);
+	fixIcueBrightness(&ledController, 0);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ After that, you can upload another sketch.
 You can repeat or scale LED channel controlled by iCUE onto physical LED strips.
 This is very useful if you have very long LED strips that are longer than 60/96/135 LEDs, which is the maximum number iCUE supports.
 
-To repeat or scale a LED channel you must apply the `CLP::repeat` or the `CLP:scale` function in the update hook of the FastLEDController.
+To repeat or scale a LED channel you must apply the `CorsairLightingProtocol::repeat` or the `CorsairLightingProtocol::scale` function in the update hook of the FastLEDController.
 See the [RepeatAndScale](examples/RepeatAndScale/RepeatAndScale.ino) example for the complete code.
 Both functions take the FastLEDController pointer and the channel index as arguments.
 Additionally, the `repeat` function takes as an argument how often the LED channel should be repeated.
@@ -149,12 +149,12 @@ This means if your LED channel from iCUE has 50 LEDs and you use the `repeat` fu
 ## Increase the Brightness of the LEDs
 When using LS100 or LT100 iCUE only uses 50% of the LEDs brightness even if you set the brightness to max in the iCUE Device Settings.
 But there are good news, we can increase the brightness with the Arduino so we can use the full brightness of our LEDs.
-Add the `CLP::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AmbientBacklight/AmbientBacklight.ino).
+Add the `CorsairLightingProtocol::fixIcueBrightness` function to the `onUpdateHook` in the setup function as shown in the [example](examples/AmbientBacklight/AmbientBacklight.ino).
 If there are multiple functions called in `onUpdateHook`, `fixIcueBrightness` should be the first.
 Only use this function with LS100 and LT100 devices!
 ```C++
 ledController.onUpdateHook(0, []() {
-	CLP::fixIcueBrightness(&ledController, 0);
+	CorsairLightingProtocol::fixIcueBrightness(&ledController, 0);
 });
 ```
 

--- a/examples/AdditionalFeatures/AdditionalFeatures.ino
+++ b/examples/AdditionalFeatures/AdditionalFeatures.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
@@ -33,11 +34,11 @@ CorsairLightingProtocolHID cHID(&cLP, mySerialNumber);
 
 void setup() {
 	// Disable the build in RX and TX LEDs of the Arduino
-	CLP::disableBuildInLEDs();
+	disableBuildInLEDs();
 	// enable reset on DeviceId (FF FF FF FF)
-	if (CLP::shouldReset(&firmware)) {
+	if (shouldReset(&firmware)) {
 		// reset DeviceId and generate new one
-		CLP::reset(&firmware);
+		reset(&firmware);
 		// reset the LEDController Settings
 		ledController.reset();
 	}
@@ -52,6 +53,6 @@ void loop() {
 
 	if (ledController.updateLEDs()) {
 		FastLED.show();
-		CLP::printFps(5000);
+		CorsairLightingProtocol::printFps(5000);
 	}
 }

--- a/examples/AdditionalFeatures/AdditionalFeatures.ino
+++ b/examples/AdditionalFeatures/AdditionalFeatures.ino
@@ -53,6 +53,6 @@ void loop() {
 
 	if (ledController.updateLEDs()) {
 		FastLED.show();
-		CorsairLightingProtocol::printFps(5000);
+		printFps(5000);
 	}
 }

--- a/examples/AmbientBacklight/AmbientBacklight.ino
+++ b/examples/AmbientBacklight/AmbientBacklight.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 // Hint: The channels are swapped in iCUE, so the first channel in iCUE is here channel 2
 #define DATA_PIN_CHANNEL_1 2  // For the monitor backlight
@@ -35,9 +36,9 @@ void setup() {
 	ledController.addLEDs(1, ledsChannel2, 105);
 	ledController.onUpdateHook(0, []() {
 		// increase the brightness of channel 1 when using iCUE, because iCUE only set brightness to max 50%
-		CorsairLightingProtocol::fixIcueBrightness(&ledController, 0);
+		fixIcueBrightness(&ledController, 0);
 		// gamma correction with gamma value 2.0. Use napplyGamma_video for other gamma values.
-		CorsairLightingProtocol::gammaCorrection(&ledController, 0);
+		gammaCorrection(&ledController, 0);
 		// napplyGamma_video(ledsChannel1, 84, 2.2);
 	});
 }

--- a/examples/AmbientBacklight/AmbientBacklight.ino
+++ b/examples/AmbientBacklight/AmbientBacklight.ino
@@ -35,9 +35,9 @@ void setup() {
 	ledController.addLEDs(1, ledsChannel2, 105);
 	ledController.onUpdateHook(0, []() {
 		// increase the brightness of channel 1 when using iCUE, because iCUE only set brightness to max 50%
-		CLP::fixIcueBrightness(&ledController, 0);
+		CorsairLightingProtocol::fixIcueBrightness(&ledController, 0);
 		// gamma correction with gamma value 2.0. Use napplyGamma_video for other gamma values.
-		CLP::gammaCorrection(&ledController, 0);
+		CorsairLightingProtocol::gammaCorrection(&ledController, 0);
 		// napplyGamma_video(ledsChannel1, 84, 2.2);
 	});
 }

--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -50,7 +50,7 @@ PWMFan fan3(PWM_FAN_PIN_3, 0, 2000);
 PWMFan fan4(PWM_FAN_PIN_4, 0, 2000);
 
 void setup() {
-	CLP::disableBuildInLEDs();
+	CorsairLightingProtocol::disableBuildInLEDs();
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_1, GRB>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_2, GRB>(ledsChannel2, CHANNEL_LED_COUNT);
 	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);

--- a/examples/CommanderPRO/CommanderPRO.ino
+++ b/examples/CommanderPRO/CommanderPRO.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #include "SimpleFanController.h"
 #include "ThermistorTemperatureController.h"
@@ -50,7 +51,7 @@ PWMFan fan3(PWM_FAN_PIN_3, 0, 2000);
 PWMFan fan4(PWM_FAN_PIN_4, 0, 2000);
 
 void setup() {
-	CorsairLightingProtocol::disableBuildInLEDs();
+	disableBuildInLEDs();
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_1, GRB>(ledsChannel1, CHANNEL_LED_COUNT);
 	FastLED.addLeds<WS2812B, DATA_PIN_CHANNEL_2, GRB>(ledsChannel2, CHANNEL_LED_COUNT);
 	ledController.addLEDs(0, ledsChannel1, CHANNEL_LED_COUNT);

--- a/examples/DebugSketch/DebugSketch.ino
+++ b/examples/DebugSketch/DebugSketch.ino
@@ -48,7 +48,7 @@ void loop() {
 	if (ledController.updateLEDs()) {
 		if (printUpdate) Serial.println(F("updateLEDs"));
 		FastLED.show();
-		CLP::printFps(5000);
+		CorsairLightingProtocol::printFps(5000);
 	}
 
 	if (Serial.available()) {
@@ -62,7 +62,7 @@ void processCommand(String& cmd) {
 	if (cmd == F("print DeviceID")) {
 		byte deviceId[4];
 		firmware.getDeviceID(deviceId);
-		CLP::printDeviceID(deviceId);
+		CorsairLightingProtocol::printDeviceID(deviceId);
 		Serial.println();
 	}
 #ifdef VERBOSE

--- a/examples/DebugSketch/DebugSketch.ino
+++ b/examples/DebugSketch/DebugSketch.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define CHANNEL_LED_COUNT 96
 
@@ -48,7 +49,7 @@ void loop() {
 	if (ledController.updateLEDs()) {
 		if (printUpdate) Serial.println(F("updateLEDs"));
 		FastLED.show();
-		CorsairLightingProtocol::printFps(5000);
+		printFps(5000);
 	}
 
 	if (Serial.available()) {
@@ -62,7 +63,7 @@ void processCommand(String& cmd) {
 	if (cmd == F("print DeviceID")) {
 		byte deviceId[4];
 		firmware.getDeviceID(deviceId);
-		CorsairLightingProtocol::printDeviceID(deviceId);
+		printDeviceID(deviceId);
 		Serial.println();
 	}
 #ifdef VERBOSE

--- a/examples/DeviceIDTool/DeviceIDTool.ino
+++ b/examples/DeviceIDTool/DeviceIDTool.ino
@@ -31,7 +31,7 @@ void setup() {
 		;  // wait for serial port to connect. Needed for native USB
 	}
 	Serial.print(F("Current DeviceID: "));
-	CLP::printDeviceID(deviceID);
+	CorsairLightingProtocol::printDeviceID(deviceID);
 	Serial.println();
 	Serial.println(
 		F("Set a new DeviceID by typing it in the Serial Monitor. The new DeviceID must be in same format as above. 4 "
@@ -54,14 +54,14 @@ void loop() {
 			newDeviceID[2] = strtol(&inputString[6], nullptr, 16);
 			newDeviceID[3] = strtol(&inputString[9], nullptr, 16);
 			Serial.println(F("Set DeviceID to: "));
-			CLP::printDeviceID(newDeviceID);
+			CorsairLightingProtocol::printDeviceID(newDeviceID);
 			Serial.println();
-			if (CLP::isNullID(newDeviceID)) {
+			if (CorsairLightingProtocol::isNullID(newDeviceID)) {
 				Serial.println(
 					F("This is a special DeviceID, it will generate a new random DeviceID next time iCUE controls the "
 					  "device!"));
 			}
-			if (CLP::isResetID(newDeviceID)) {
+			if (CorsairLightingProtocol::isResetID(newDeviceID)) {
 				Serial.println(
 					F("This is a special DeviceID, it will reset the device and then generate a new DeviceID!"));
 			}

--- a/examples/DeviceIDTool/DeviceIDTool.ino
+++ b/examples/DeviceIDTool/DeviceIDTool.ino
@@ -18,6 +18,7 @@
 //
 #include <CLPUtils.h>
 #include <EEPROM.h>
+using namespace CorsairLightingProtocol;
 
 #define EEPROM_ADDRESS_DEVICE_ID 0
 
@@ -31,7 +32,7 @@ void setup() {
 		;  // wait for serial port to connect. Needed for native USB
 	}
 	Serial.print(F("Current DeviceID: "));
-	CorsairLightingProtocol::printDeviceID(deviceID);
+	printDeviceID(deviceID);
 	Serial.println();
 	Serial.println(
 		F("Set a new DeviceID by typing it in the Serial Monitor. The new DeviceID must be in same format as above. 4 "
@@ -54,14 +55,14 @@ void loop() {
 			newDeviceID[2] = strtol(&inputString[6], nullptr, 16);
 			newDeviceID[3] = strtol(&inputString[9], nullptr, 16);
 			Serial.println(F("Set DeviceID to: "));
-			CorsairLightingProtocol::printDeviceID(newDeviceID);
+			printDeviceID(newDeviceID);
 			Serial.println();
-			if (CorsairLightingProtocol::isNullID(newDeviceID)) {
+			if (isNullID(newDeviceID)) {
 				Serial.println(
 					F("This is a special DeviceID, it will generate a new random DeviceID next time iCUE controls the "
 					  "device!"));
 			}
-			if (CorsairLightingProtocol::isResetID(newDeviceID)) {
+			if (isResetID(newDeviceID)) {
 				Serial.println(
 					F("This is a special DeviceID, it will reset the device and then generate a new DeviceID!"));
 			}

--- a/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
+++ b/examples/HoodLoader2CLPBridge/CLPUSBSerialBridge.cpp
@@ -29,12 +29,12 @@ void resetIOMCU() {
 }
 
 CLPUSBSerialBridge::CLPUSBSerialBridge(const char* serialNumber) {
-	CLP::RawHID.setSerialNumber(serialNumber);
+	CorsairLightingProtocol::RawHID.setSerialNumber(serialNumber);
 }
 
 void CLPUSBSerialBridge::begin() {
 	Serial1.begin(SERIAL_BAUD);
-	CLP::RawHID.begin(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
+	CorsairLightingProtocol::RawHID.begin(rawHIDAndSerialBuffer, sizeof(rawHIDAndSerialBuffer));
 }
 
 bool waitForSynchronization() {
@@ -58,13 +58,13 @@ void CLPUSBSerialBridge::sendResponse() {
 	Serial.print(F("R"));
 	Serial.println(rawHIDAndSerialBuffer[0], HEX);
 #endif  // DEBUG
-	CLP::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE_16U2);
+	CorsairLightingProtocol::RawHID.write(rawHIDAndSerialBuffer, RESPONSE_SIZE_16U2);
 	// free the shared buffer to receive new data
-	CLP::RawHID.enable();
+	CorsairLightingProtocol::RawHID.enable();
 }
 
 void CLPUSBSerialBridge::handleHID() {
-	if (CLP::RawHID.available()) {
+	if (CorsairLightingProtocol::RawHID.available()) {
 #ifdef DEBUG
 		Serial.print(F("C"));
 		Serial.println(rawHIDAndSerialBuffer[0], HEX);

--- a/examples/HoodLoader2CLPBridge/HoodLoader2CLPBridge.ino
+++ b/examples/HoodLoader2CLPBridge/HoodLoader2CLPBridge.ino
@@ -14,6 +14,7 @@
    limitations under the License.
 */
 #include "CLPUSBSerialBridge.h"
+using namespace CorsairLightingProtocol;
 
 CLPUSBSerialBridge usbToSerialBridge;
 

--- a/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
+++ b/examples/HoodLoader2UnoMegaController/HoodLoader2UnoMegaController.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 // Hint: The Arduino Uno does not have as much memory as the Arduino Mega, it may be that problems occur when a higher
 // value is set here.

--- a/examples/LS100/LS100.ino
+++ b/examples/LS100/LS100.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 // Hint: The channels of the LS100 are swapped in iCUE, so the first channel in iCUE is here channel 2
 #define DATA_PIN_CHANNEL_1 2

--- a/examples/LT100/LT100.ino
+++ b/examples/LT100/LT100.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 

--- a/examples/LightingNodeCORE/LightingNodeCORE.ino
+++ b/examples/LightingNodeCORE/LightingNodeCORE.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 

--- a/examples/LightingNodePRO/LightingNodePRO.ino
+++ b/examples/LightingNodePRO/LightingNodePRO.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3

--- a/examples/MultipleFans/MultipleFans.ino
+++ b/examples/MultipleFans/MultipleFans.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define NUMBER_OF_LEDS_PER_FAN 8
 

--- a/examples/NonAddressable/NonAddressable.ino
+++ b/examples/NonAddressable/NonAddressable.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 // The Arduino pin where the physical LEDs are connected.
 // Must be PWM pins

--- a/examples/RepeatAndScale/RepeatAndScale.ino
+++ b/examples/RepeatAndScale/RepeatAndScale.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
@@ -33,10 +34,10 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 50);
 	ledController.addLEDs(1, ledsChannel2, 60);
 	ledController.onUpdateHook(0, []() {
-		CorsairLightingProtocol::repeat(&ledController, 0, 2);
+		repeat(&ledController, 0, 2);
 	});
 	ledController.onUpdateHook(1, []() {
-		CorsairLightingProtocol::scale(&ledController, 1, 144);
+		scale(&ledController, 1, 144);
 	});
 }
 

--- a/examples/RepeatAndScale/RepeatAndScale.ino
+++ b/examples/RepeatAndScale/RepeatAndScale.ino
@@ -33,10 +33,10 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 50);
 	ledController.addLEDs(1, ledsChannel2, 60);
 	ledController.onUpdateHook(0, []() {
-		CLP::repeat(&ledController, 0, 2);
+		CorsairLightingProtocol::repeat(&ledController, 0, 2);
 	});
 	ledController.onUpdateHook(1, []() {
-		CLP::scale(&ledController, 1, 144);
+		CorsairLightingProtocol::scale(&ledController, 1, 144);
 	});
 }
 

--- a/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
+++ b/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 // The number of LEDs per channel.
 #define CHANNEL_LED_COUNT 50
@@ -39,7 +40,7 @@ void setup() {
 #ifdef DEBUG
 	Serial.begin(115200);
 #endif
-	CorsairLightingProtocol::disableBuildInLEDs();
+	disableBuildInLEDs();
 	FastLED.addLeds<WS2812B, DATA_PIN, GRB>(leds, NUM_LEDS);
 	ledController.addLEDs(0, leds, CHANNEL_LED_COUNT);
 	ledController.addLEDs(1, &(leds[CHANNEL_LED_COUNT]), CHANNEL_LED_COUNT);

--- a/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
+++ b/examples/SingleStripLightingNodePRO/SingleStripLightingNodePRO.ino
@@ -39,7 +39,7 @@ void setup() {
 #ifdef DEBUG
 	Serial.begin(115200);
 #endif
-	CLP::disableBuildInLEDs();
+	CorsairLightingProtocol::disableBuildInLEDs();
 	FastLED.addLeds<WS2812B, DATA_PIN, GRB>(leds, NUM_LEDS);
 	ledController.addLEDs(0, leds, CHANNEL_LED_COUNT);
 	ledController.addLEDs(1, &(leds[CHANNEL_LED_COUNT]), CHANNEL_LED_COUNT);

--- a/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
+++ b/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
@@ -15,6 +15,7 @@
 */
 #include <CorsairLightingProtocol.h>
 #include <FastLED.h>
+using namespace CorsairLightingProtocol;
 
 #define DATA_PIN_CHANNEL_1 2
 #define DATA_PIN_CHANNEL_2 3
@@ -33,7 +34,7 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 96);
 	ledController.addLEDs(1, ledsChannel2, 60);
 	ledController.onUpdateHook(0, []() {
-		CorsairLightingProtocol::transformLLFanToStrip(&ledController, 0);
+		transformLLFanToStrip(&ledController, 0);
 	});
 }
 

--- a/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
+++ b/examples/TransformLLFansFormatToStrip/TransformLLFansFormatToStrip.ino
@@ -33,7 +33,7 @@ void setup() {
 	ledController.addLEDs(0, ledsChannel1, 96);
 	ledController.addLEDs(1, ledsChannel2, 60);
 	ledController.onUpdateHook(0, []() {
-		CLP::transformLLFanToStrip(&ledController, 0);
+		CorsairLightingProtocol::transformLLFanToStrip(&ledController, 0);
 	});
 }
 

--- a/examples/UnitTests/UnitTests.ino
+++ b/examples/UnitTests/UnitTests.ino
@@ -50,7 +50,7 @@ testF(FastLEDControllerTest, simpleScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::scale(&ledController, 0, 20);
+	CorsairLightingProtocol::scale(&ledController, 0, 20);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 }
@@ -62,7 +62,7 @@ testF(FastLEDControllerTest, simpleScaleDown) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::scale(&ledController, 0, 10);
+	CorsairLightingProtocol::scale(&ledController, 0, 10);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 9, CRGB::Black);
@@ -76,7 +76,7 @@ testF(FastLEDControllerTest, simpleScaleDownBoundaries) {
 
 	leds[0] = CRGB::White;
 	leds[19] = CRGB::Red;
-	CLP::scale(&ledController, 0, 5);
+	CorsairLightingProtocol::scale(&ledController, 0, 5);
 
 	assertCRGBArray(leds, 0, 0, CRGB::White);
 	assertCRGBArray(leds, 1, 3, CRGB::Black);
@@ -90,7 +90,7 @@ testF(FastLEDControllerTest, simpleScaleIdentity) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::scale(&ledController, 0, 10);
+	CorsairLightingProtocol::scale(&ledController, 0, 10);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 	assertCRGBArray(leds, 10, 19, CRGB::Black);
@@ -103,7 +103,7 @@ testF(FastLEDControllerTest, scaleLongStrip) {
 	ledController.addLEDs(0, leds, 27);
 
 	fill_solid(leds, 27, CRGB::White);
-	CLP::scale(&ledController, 0, 41);
+	CorsairLightingProtocol::scale(&ledController, 0, 41);
 
 	assertCRGBArray(leds, 0, 40, CRGB::White);
 }
@@ -116,8 +116,8 @@ testF(FastLEDControllerTest, LT100) {
 
 	leds[0] = CRGB::White;
 	fill_solid(leds + 1, 26, CRGB::Blue);
-	CLP::SegmentScaling segments[2] = {{1, 4}, {26, 26}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[2] = {{1, 4}, {26, 26}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 3, CRGB::White);
 	assertCRGBArray(leds, 4, 29, CRGB::Blue);
@@ -130,8 +130,8 @@ testF(FastLEDControllerTest, singleSegmentScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::SegmentScaling segments[] = {{10, 20}};
-	CLP::scaleSegments(&ledController, 0, segments, 1);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 20}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
 
 	assertCRGBArray(leds, 0, 19, CRGB::White);
 }
@@ -143,8 +143,8 @@ testF(FastLEDControllerTest, multiScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds + 5, 5, CRGB::White);
-	CLP::SegmentScaling segments[] = {{5, 10}, {5, 20}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {5, 20}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 9, CRGB::Black);
 	assertCRGBArray(leds, 10, 29, CRGB::White);
@@ -157,8 +157,8 @@ testF(FastLEDControllerTest, multiScaleDown) {
 	ledController.addLEDs(0, leds, 30);
 
 	fill_solid(leds + 10, 20, CRGB::White);
-	CLP::SegmentScaling segments[] = {{10, 5}, {20, 5}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {20, 5}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 4, CRGB::Black);
 	assertCRGBArray(leds, 5, 9, CRGB::White);
@@ -171,8 +171,8 @@ testF(FastLEDControllerTest, singleSegmentScaleDown) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::SegmentScaling segments[] = {{20, 10}};
-	CLP::scaleSegments(&ledController, 0, segments, 1);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{20, 10}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 9, CRGB::Black);
@@ -185,8 +185,8 @@ testF(FastLEDControllerTest, SegmentScaleOverlap) {
 	ledController.addLEDs(0, leds, 15);
 
 	fill_solid(leds, 5, CRGB::White);
-	CLP::SegmentScaling segments[] = {{5, 10}, {10, 5}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {10, 5}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 	assertCRGBArray(leds, 10, 14, CRGB::Black);
@@ -199,8 +199,8 @@ testF(FastLEDControllerTest, SegmentScaleOverlapInverted) {
 	ledController.addLEDs(0, leds, 15);
 
 	fill_solid(leds, 10, CRGB::White);
-	CLP::SegmentScaling segments[] = {{10, 5}, {5, 10}};
-	CLP::scaleSegments(&ledController, 0, segments, 2);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {5, 10}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 14, CRGB::Black);
@@ -215,8 +215,8 @@ testF(FastLEDControllerTest, SegmentScaleMix) {
 	fill_solid(leds, 5, CRGB::White);
 	fill_solid(leds + 5, 20, CRGB::Red);
 	fill_solid(leds + 25, 5, CRGB::Blue);
-	CLP::SegmentScaling segments[] = {{5, 10}, {20, 5}, {5, 10}};
-	CLP::scaleSegments(&ledController, 0, segments, 3);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {20, 5}, {5, 10}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 3);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 	assertCRGBArray(leds, 10, 14, CRGB::Red);
@@ -232,8 +232,8 @@ testF(FastLEDControllerTest, SegmentScaleMixInverted) {
 	fill_solid(leds, 10, CRGB::White);
 	fill_solid(leds + 10, 5, CRGB::Red);
 	fill_solid(leds + 15, 10, CRGB::Blue);
-	CLP::SegmentScaling segments[] = {{10, 5}, {5, 20}, {10, 5}};
-	CLP::scaleSegments(&ledController, 0, segments, 3);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {5, 20}, {10, 5}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 3);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 24, CRGB::Red);
@@ -250,8 +250,8 @@ testF(FastLEDControllerTest, SegmentScaleMonitor) {
 	fill_solid(leds + 15, 27, CRGB::Red);
 	fill_solid(leds + 42, 15, CRGB::Blue);
 	fill_solid(leds + 57, 27, CRGB::Green);
-	CLP::SegmentScaling segments[] = {{15, 24}, {27, 41}, {15, 24}, {27, 41}};
-	CLP::scaleSegments(&ledController, 0, segments, 4);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{15, 24}, {27, 41}, {15, 24}, {27, 41}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 4);
 
 	assertCRGBArray(leds, 0, 23, CRGB::White);
 	assertCRGBArray(leds, 24, 64, CRGB::Red);
@@ -266,8 +266,8 @@ testF(FastLEDControllerTest, SegmentScaleLongStrip) {
 	ledController.addLEDs(0, leds, 27);
 
 	fill_solid(leds, 27, CRGB::White);
-	CLP::SegmentScaling segments[] = {{27, 41}};
-	CLP::scaleSegments(&ledController, 0, segments, 1);
+	CorsairLightingProtocol::SegmentScaling segments[] = {{27, 41}};
+	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
 
 	assertCRGBArray(leds, 0, 40, CRGB::White);
 }

--- a/examples/UnitTests/UnitTests.ino
+++ b/examples/UnitTests/UnitTests.ino
@@ -19,6 +19,7 @@
 
 #include "FastLEDControllerUtils.h"
 
+using namespace CorsairLightingProtocol;
 using namespace aunit;
 
 class FastLEDControllerTest : public TestOnce {
@@ -50,7 +51,7 @@ testF(FastLEDControllerTest, simpleScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CorsairLightingProtocol::scale(&ledController, 0, 20);
+	scale(&ledController, 0, 20);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 }
@@ -62,7 +63,7 @@ testF(FastLEDControllerTest, simpleScaleDown) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CorsairLightingProtocol::scale(&ledController, 0, 10);
+	scale(&ledController, 0, 10);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 9, CRGB::Black);
@@ -76,7 +77,7 @@ testF(FastLEDControllerTest, simpleScaleDownBoundaries) {
 
 	leds[0] = CRGB::White;
 	leds[19] = CRGB::Red;
-	CorsairLightingProtocol::scale(&ledController, 0, 5);
+	scale(&ledController, 0, 5);
 
 	assertCRGBArray(leds, 0, 0, CRGB::White);
 	assertCRGBArray(leds, 1, 3, CRGB::Black);
@@ -90,7 +91,7 @@ testF(FastLEDControllerTest, simpleScaleIdentity) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CorsairLightingProtocol::scale(&ledController, 0, 10);
+	scale(&ledController, 0, 10);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 	assertCRGBArray(leds, 10, 19, CRGB::Black);
@@ -103,7 +104,7 @@ testF(FastLEDControllerTest, scaleLongStrip) {
 	ledController.addLEDs(0, leds, 27);
 
 	fill_solid(leds, 27, CRGB::White);
-	CorsairLightingProtocol::scale(&ledController, 0, 41);
+	scale(&ledController, 0, 41);
 
 	assertCRGBArray(leds, 0, 40, CRGB::White);
 }
@@ -116,8 +117,8 @@ testF(FastLEDControllerTest, LT100) {
 
 	leds[0] = CRGB::White;
 	fill_solid(leds + 1, 26, CRGB::Blue);
-	CorsairLightingProtocol::SegmentScaling segments[2] = {{1, 4}, {26, 26}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
+	SegmentScaling segments[2] = {{1, 4}, {26, 26}};
+	scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 3, CRGB::White);
 	assertCRGBArray(leds, 4, 29, CRGB::Blue);
@@ -130,8 +131,8 @@ testF(FastLEDControllerTest, singleSegmentScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds, 10, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 20}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
+	SegmentScaling segments[] = {{10, 20}};
+	scaleSegments(&ledController, 0, segments, 1);
 
 	assertCRGBArray(leds, 0, 19, CRGB::White);
 }
@@ -143,8 +144,8 @@ testF(FastLEDControllerTest, multiScaleUp) {
 	ledController.addLEDs(0, leds, 10);
 
 	fill_solid(leds + 5, 5, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {5, 20}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
+	SegmentScaling segments[] = {{5, 10}, {5, 20}};
+	scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 9, CRGB::Black);
 	assertCRGBArray(leds, 10, 29, CRGB::White);
@@ -157,8 +158,8 @@ testF(FastLEDControllerTest, multiScaleDown) {
 	ledController.addLEDs(0, leds, 30);
 
 	fill_solid(leds + 10, 20, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {20, 5}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
+	SegmentScaling segments[] = {{10, 5}, {20, 5}};
+	scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 4, CRGB::Black);
 	assertCRGBArray(leds, 5, 9, CRGB::White);
@@ -171,8 +172,8 @@ testF(FastLEDControllerTest, singleSegmentScaleDown) {
 	ledController.addLEDs(0, leds, 20);
 
 	fill_solid(leds, 10, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{20, 10}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
+	SegmentScaling segments[] = {{20, 10}};
+	scaleSegments(&ledController, 0, segments, 1);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 9, CRGB::Black);
@@ -185,8 +186,8 @@ testF(FastLEDControllerTest, SegmentScaleOverlap) {
 	ledController.addLEDs(0, leds, 15);
 
 	fill_solid(leds, 5, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {10, 5}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
+	SegmentScaling segments[] = {{5, 10}, {10, 5}};
+	scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 	assertCRGBArray(leds, 10, 14, CRGB::Black);
@@ -199,8 +200,8 @@ testF(FastLEDControllerTest, SegmentScaleOverlapInverted) {
 	ledController.addLEDs(0, leds, 15);
 
 	fill_solid(leds, 10, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {5, 10}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 2);
+	SegmentScaling segments[] = {{10, 5}, {5, 10}};
+	scaleSegments(&ledController, 0, segments, 2);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 14, CRGB::Black);
@@ -215,8 +216,8 @@ testF(FastLEDControllerTest, SegmentScaleMix) {
 	fill_solid(leds, 5, CRGB::White);
 	fill_solid(leds + 5, 20, CRGB::Red);
 	fill_solid(leds + 25, 5, CRGB::Blue);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{5, 10}, {20, 5}, {5, 10}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 3);
+	SegmentScaling segments[] = {{5, 10}, {20, 5}, {5, 10}};
+	scaleSegments(&ledController, 0, segments, 3);
 
 	assertCRGBArray(leds, 0, 9, CRGB::White);
 	assertCRGBArray(leds, 10, 14, CRGB::Red);
@@ -232,8 +233,8 @@ testF(FastLEDControllerTest, SegmentScaleMixInverted) {
 	fill_solid(leds, 10, CRGB::White);
 	fill_solid(leds + 10, 5, CRGB::Red);
 	fill_solid(leds + 15, 10, CRGB::Blue);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{10, 5}, {5, 20}, {10, 5}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 3);
+	SegmentScaling segments[] = {{10, 5}, {5, 20}, {10, 5}};
+	scaleSegments(&ledController, 0, segments, 3);
 
 	assertCRGBArray(leds, 0, 4, CRGB::White);
 	assertCRGBArray(leds, 5, 24, CRGB::Red);
@@ -250,8 +251,8 @@ testF(FastLEDControllerTest, SegmentScaleMonitor) {
 	fill_solid(leds + 15, 27, CRGB::Red);
 	fill_solid(leds + 42, 15, CRGB::Blue);
 	fill_solid(leds + 57, 27, CRGB::Green);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{15, 24}, {27, 41}, {15, 24}, {27, 41}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 4);
+	SegmentScaling segments[] = {{15, 24}, {27, 41}, {15, 24}, {27, 41}};
+	scaleSegments(&ledController, 0, segments, 4);
 
 	assertCRGBArray(leds, 0, 23, CRGB::White);
 	assertCRGBArray(leds, 24, 64, CRGB::Red);
@@ -266,8 +267,8 @@ testF(FastLEDControllerTest, SegmentScaleLongStrip) {
 	ledController.addLEDs(0, leds, 27);
 
 	fill_solid(leds, 27, CRGB::White);
-	CorsairLightingProtocol::SegmentScaling segments[] = {{27, 41}};
-	CorsairLightingProtocol::scaleSegments(&ledController, 0, segments, 1);
+	SegmentScaling segments[] = {{27, 41}};
+	scaleSegments(&ledController, 0, segments, 1);
 
 	assertCRGBArray(leds, 0, 40, CRGB::White);
 }

--- a/src/CLPAdditionalFeatures.cpp
+++ b/src/CLPAdditionalFeatures.cpp
@@ -17,13 +17,13 @@
 
 #include "CLPUtils.h"
 
-bool CLP::shouldReset(const CorsairLightingFirmware* firmware) {
+bool CorsairLightingProtocol::shouldReset(const CorsairLightingFirmware* firmware) {
 	byte deviceId[4];
 	firmware->getDeviceID(deviceId);
-	return CLP::isResetID(deviceId);
+	return CorsairLightingProtocol::isResetID(deviceId);
 }
 
-void CLP::reset(CorsairLightingFirmware* firmware) {
+void CorsairLightingProtocol::reset(CorsairLightingFirmware* firmware) {
 	byte deviceId[4] = {0x00};
 	firmware->setDeviceID(deviceId);
 }

--- a/src/CLPAdditionalFeatures.h
+++ b/src/CLPAdditionalFeatures.h
@@ -18,7 +18,7 @@
 #include "Arduino.h"
 #include "CorsairLightingFirmware.h"
 
-namespace CLP {
+namespace CorsairLightingProtocol {
 /**
  * Check if the device should be reseted. The check is based on the DeviceID from the firmware.
  *
@@ -33,4 +33,4 @@ bool shouldReset(const CorsairLightingFirmware* firmware);
  * @param firmware reset this firmware
  */
 void reset(CorsairLightingFirmware* firmware);
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol

--- a/src/CLPUtils.cpp
+++ b/src/CLPUtils.cpp
@@ -15,14 +15,14 @@
 */
 #include "CLPUtils.h"
 
-uint16_t CLP::fromBigEndian(const byte& byte1, const byte& byte2) {
+uint16_t CorsairLightingProtocol::fromBigEndian(const byte& byte1, const byte& byte2) {
 	uint16_t t = byte1;
 	t = t << 8;
 	t |= byte2;
 	return t;
 }
 
-void CLP::disableBuildInLEDs() {
+void CorsairLightingProtocol::disableBuildInLEDs() {
 #ifndef DEBUG
 #ifdef LED_BUILTIN_RX
 	pinMode(LED_BUILTIN_RX, INPUT);
@@ -33,13 +33,15 @@ void CLP::disableBuildInLEDs() {
 #endif
 }
 
-bool CLP::isNullID(const uint8_t* deviceId) { return !(deviceId[0] | deviceId[1] | deviceId[2] | deviceId[3]); }
+bool CorsairLightingProtocol::isNullID(const uint8_t* deviceId) {
+	return !(deviceId[0] | deviceId[1] | deviceId[2] | deviceId[3]);
+}
 
-bool CLP::isResetID(const uint8_t* deviceId) {
+bool CorsairLightingProtocol::isResetID(const uint8_t* deviceId) {
 	return deviceId[0] == 0xFF && deviceId[1] == 0xFF && deviceId[2] == 0xFF && deviceId[3] == 0xFF;
 }
 
-void CLP::printDeviceID(const uint8_t* deviceId) {
+void CorsairLightingProtocol::printDeviceID(const uint8_t* deviceId) {
 	char tmp[16];
 	for (size_t i = 0; i < 4; i++) {
 		sprintf(tmp, "%.2X", deviceId[i]);
@@ -48,7 +50,7 @@ void CLP::printDeviceID(const uint8_t* deviceId) {
 	}
 }
 
-void CLP::printFps(const int interval) {
+void CorsairLightingProtocol::printFps(const int interval) {
 	// Create static variables so that the code and variables can
 	// all be declared inside a function
 	static unsigned long lastMillis;

--- a/src/CLPUtils.h
+++ b/src/CLPUtils.h
@@ -19,7 +19,7 @@
 
 #define toBigEndian(a) highByte(a), lowByte(a)
 
-namespace CLP {
+namespace CorsairLightingProtocol {
 uint16_t fromBigEndian(const byte& byte1, const byte& byte2);
 
 /**
@@ -69,4 +69,4 @@ void printDeviceID(const uint8_t* deviceId);
  * @param interval the measurement interval in milliseconds
  */
 void printFps(const int interval);
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol

--- a/src/CorsairLightingFirmware.cpp
+++ b/src/CorsairLightingFirmware.cpp
@@ -29,7 +29,7 @@ CorsairLightingFirmware::CorsairLightingFirmware(const uint8_t* firmwareVersion)
 	EEPROM.get(EEPROM_ADDRESS_DEVICE_ID, deviceId);
 }
 
-void CorsairLightingFirmware::handleFirmwareCommand(const Command& command,
+void CorsairLightingFirmware::handleFirmwareCommand(const CorsairLightingProtocol::Command& command,
 													const CorsairLightingProtocolResponse* response) {
 	switch (command.command) {
 		case READ_STATUS: {

--- a/src/CorsairLightingFirmware.h
+++ b/src/CorsairLightingFirmware.h
@@ -31,7 +31,7 @@
 class CorsairLightingFirmware {
 public:
 	CorsairLightingFirmware(const uint8_t* firmwareVersion);
-	void handleFirmwareCommand(const Command& command, const CorsairLightingProtocolResponse* response);
+	void handleFirmwareCommand(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response);
 	void getDeviceID(uint8_t* deviceID) const;
 	void setDeviceID(const uint8_t* deviceID);
 	uint8_t getStatus();

--- a/src/CorsairLightingProtocolConstants.h
+++ b/src/CorsairLightingProtocolConstants.h
@@ -61,6 +61,7 @@
 #define PROTOCOL_RESPONSE_OK 0x00
 #define PROTOCOL_RESPONSE_ERROR 0x01
 
+namespace CorsairLightingProtocol {
 struct Command {
 	union {
 		struct {
@@ -70,3 +71,4 @@ struct Command {
 		uint8_t raw[COMMAND_SIZE];
 	};
 };
+};  // namespace CorsairLightingProtocol

--- a/src/CorsairLightingProtocolController.cpp
+++ b/src/CorsairLightingProtocolController.cpp
@@ -33,7 +33,7 @@ CorsairLightingProtocolController::CorsairLightingProtocolController(ILEDControl
 	  temperatureController(temperatureController),
 	  fanController(fanController) {}
 
-void CorsairLightingProtocolController::handleCommand(const Command& command,
+void CorsairLightingProtocolController::handleCommand(const CorsairLightingProtocol::Command& command,
 													  CorsairLightingProtocolResponse* response) {
 	if (command.command < 0x10) {
 		corsairLightingFirmware->handleFirmwareCommand(command, response);

--- a/src/CorsairLightingProtocolController.h
+++ b/src/CorsairLightingProtocolController.h
@@ -56,7 +56,7 @@ public:
 	 * @param command The command received from iCUE
 	 * @param response The response callback which can be called to response to the command
 	 */
-	void handleCommand(const Command& command, CorsairLightingProtocolResponse* response);
+	void handleCommand(const CorsairLightingProtocol::Command& command, CorsairLightingProtocolResponse* response);
 
 private:
 	CorsairLightingFirmware* const corsairLightingFirmware;

--- a/src/CorsairLightingProtocolHID.cpp
+++ b/src/CorsairLightingProtocolHID.cpp
@@ -35,7 +35,7 @@ CorsairLightingProtocolHID::CorsairLightingProtocolHID(CorsairLightingProtocolCo
 
 void CorsairLightingProtocolHID::update() {
 	if (available()) {
-		Command command;
+		CorsairLightingProtocol::Command command;
 		getCommand(command);
 		controller->handleCommand(command, this);
 	}
@@ -43,7 +43,7 @@ void CorsairLightingProtocolHID::update() {
 
 bool CorsairLightingProtocolHID::available() const { return CorsairLightingProtocol::RawHID.available() > 0; }
 
-void CorsairLightingProtocolHID::getCommand(Command& command) {
+void CorsairLightingProtocolHID::getCommand(CorsairLightingProtocol::Command& command) {
 	auto bytesAvailable = CorsairLightingProtocol::RawHID.available();
 	if (bytesAvailable) {
 		CorsairLightingProtocol::RawHID.readBytes(command.raw, sizeof(command.raw));

--- a/src/CorsairLightingProtocolHID.cpp
+++ b/src/CorsairLightingProtocolHID.cpp
@@ -24,13 +24,13 @@ bool printResponse = PRINT_RESPONSE;
 
 CorsairLightingProtocolHID::CorsairLightingProtocolHID(CorsairLightingProtocolController* controller)
 	: controller(controller) {
-	CLP::RawHID.begin(rawhidData, sizeof(rawhidData));
+	CorsairLightingProtocol::RawHID.begin(rawhidData, sizeof(rawhidData));
 }
 
 CorsairLightingProtocolHID::CorsairLightingProtocolHID(CorsairLightingProtocolController* controller,
 													   const char* serialNumber)
 	: CorsairLightingProtocolHID(controller) {
-	CLP::RawHID.setSerialNumber(serialNumber);
+	CorsairLightingProtocol::RawHID.setSerialNumber(serialNumber);
 }
 
 void CorsairLightingProtocolHID::update() {
@@ -41,12 +41,12 @@ void CorsairLightingProtocolHID::update() {
 	}
 }
 
-bool CorsairLightingProtocolHID::available() const { return CLP::RawHID.available() > 0; }
+bool CorsairLightingProtocolHID::available() const { return CorsairLightingProtocol::RawHID.available() > 0; }
 
 void CorsairLightingProtocolHID::getCommand(Command& command) {
-	auto bytesAvailable = CLP::RawHID.available();
+	auto bytesAvailable = CorsairLightingProtocol::RawHID.available();
 	if (bytesAvailable) {
-		CLP::RawHID.readBytes(command.raw, sizeof(command.raw));
+		CorsairLightingProtocol::RawHID.readBytes(command.raw, sizeof(command.raw));
 #if defined(DEBUG) && defined(VERBOSE)
 		if (printCommand) {
 			Serial.print(F("Received Command: "));
@@ -65,7 +65,7 @@ void CorsairLightingProtocolHID::sendX(const uint8_t* data, const size_t x) cons
 		Serial.println(data[0], HEX);
 	}
 #endif
-	CLP::RawHID.write(data, x);
+	CorsairLightingProtocol::RawHID.write(data, x);
 }
 
 #endif

--- a/src/CorsairLightingProtocolHID.h
+++ b/src/CorsairLightingProtocolHID.h
@@ -57,7 +57,7 @@ protected:
 	CorsairLightingProtocolController* const controller;
 
 	bool available() const;
-	void getCommand(Command& command);
+	void getCommand(CorsairLightingProtocol::Command& command);
 	void sendX(const uint8_t* data, const size_t x) const override;
 };
 

--- a/src/CorsairLightingProtocolSerial.cpp
+++ b/src/CorsairLightingProtocolSerial.cpp
@@ -26,7 +26,7 @@ void CorsairLightingProtocolSerial::setup() {
 void CorsairLightingProtocolSerial::update() {
 	bool available = handleSerial();
 	if (available) {
-		Command command;
+		CorsairLightingProtocol::Command command;
 		memcpy(command.raw, rawCommand, sizeof(command.raw));
 		controller->handleCommand(command, this);
 	}

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -26,7 +26,7 @@ bool isValidFanDetectionType(const FanDetectionType type) {
 		   type == FanDetectionType::Disconnected;
 }
 
-void FanController::handleFanControl(const Command& command, const CorsairLightingProtocolResponse* response) {
+void FanController::handleFanControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) {
 	switch (command.command) {
 		case READ_FAN_MASK: {
 			FanMask mask[FAN_NUM];

--- a/src/FanController.cpp
+++ b/src/FanController.cpp
@@ -67,7 +67,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				return;
 			}
 			uint8_t power = getFanPower(fan);
-			uint8_t powerData[] = {CLP::convert255To100(power)};
+			uint8_t powerData[] = {CorsairLightingProtocol::convert255To100(power)};
 			response->send(powerData, sizeof(powerData));
 			break;
 		}
@@ -77,7 +77,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				response->sendError();
 				return;
 			}
-			uint8_t percentage = CLP::convert100To255(command.data[1]);
+			uint8_t percentage = CorsairLightingProtocol::convert100To255(command.data[1]);
 			setFanPower(fan, percentage);
 			response->send(nullptr, 0);
 			break;
@@ -88,7 +88,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				response->sendError();
 				return;
 			}
-			uint16_t speed = CLP::fromBigEndian(command.data[1], command.data[2]);
+			uint16_t speed = CorsairLightingProtocol::fromBigEndian(command.data[1], command.data[2]);
 			setFanSpeed(fan, speed);
 			response->send(nullptr, 0);
 			break;
@@ -102,8 +102,10 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 			const uint8_t& group = command.data[1];
 			FanCurve fanCurve;
 			for (uint8_t i = 0; i < FAN_CURVE_POINTS_NUM; i++) {
-				fanCurve.temperatures[i] = CLP::fromBigEndian(command.data[2 + i * 2], command.data[3 + i * 2]);
-				fanCurve.rpms[i] = CLP::fromBigEndian(command.data[14 + i * 2], command.data[15 + i * 2]);
+				fanCurve.temperatures[i] =
+					CorsairLightingProtocol::fromBigEndian(command.data[2 + i * 2], command.data[3 + i * 2]);
+				fanCurve.rpms[i] =
+					CorsairLightingProtocol::fromBigEndian(command.data[14 + i * 2], command.data[15 + i * 2]);
 			}
 			setFanCurve(fan, group, fanCurve);
 			response->send(nullptr, 0);
@@ -115,7 +117,7 @@ void FanController::handleFanControl(const Command& command, const CorsairLighti
 				response->sendError();
 				return;
 			}
-			uint16_t temp = CLP::fromBigEndian(command.data[1], command.data[2]);
+			uint16_t temp = CorsairLightingProtocol::fromBigEndian(command.data[1], command.data[2]);
 			setFanExternalTemperature(fan, temp);
 			response->send(nullptr, 0);
 			break;

--- a/src/FanController.h
+++ b/src/FanController.h
@@ -87,7 +87,7 @@ struct FanCurve {
  */
 class FanController : public IFanController {
 public:
-	virtual void handleFanControl(const Command& command, const CorsairLightingProtocolResponse* response) override;
+	virtual void handleFanControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) override;
 
 protected:
 	/**

--- a/src/FastLEDControllerUtils.cpp
+++ b/src/FastLEDControllerUtils.cpp
@@ -18,7 +18,7 @@
 #include <FastLED.h>
 #include <math.h>
 
-void CLP::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::transformLLFanToStrip(FastLEDController* controller, uint8_t channelIndex) {
 	auto& channel = controller->getChannel(channelIndex);
 	if (channel.mode == ChannelMode::SoftwarePlayback) {
 		auto leds = controller->getLEDs(channelIndex);
@@ -44,7 +44,7 @@ float scaleFactorOf(const int numberLEDsBefore, const int numberLEDsAfter) {
 	return (float)(numberLEDsBefore - 1) / (numberLEDsAfter - 1);
 }
 
-void CLP::scale(FastLEDController* controller, uint8_t channelIndex, int scaleToSize) {
+void CorsairLightingProtocol::scale(FastLEDController* controller, uint8_t channelIndex, int scaleToSize) {
 	auto leds = controller->getLEDs(channelIndex);
 	const float scaleFactor = scaleFactorOf(controller->getLEDCount(channelIndex), scaleToSize);
 	if (scaleFactor < 1.0f) {
@@ -58,7 +58,7 @@ void CLP::scale(FastLEDController* controller, uint8_t channelIndex, int scaleTo
 	}
 }
 
-void CLP::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t times) {
+void CorsairLightingProtocol::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t times) {
 	auto leds = controller->getLEDs(channelIndex);
 	auto count = controller->getLEDCount(channelIndex);
 	// skip first iteration, because LEDs already contains the data at the first position
@@ -67,8 +67,8 @@ void CLP::repeat(FastLEDController* controller, uint8_t channelIndex, uint8_t ti
 	}
 }
 
-void CLP::scaleSegments(FastLEDController* controller, uint8_t channelIndex, const SegmentScaling* const segments,
-						int segmentsCount) {
+void CorsairLightingProtocol::scaleSegments(FastLEDController* controller, uint8_t channelIndex,
+											const SegmentScaling* const segments, int segmentsCount) {
 	auto leds = controller->getLEDs(channelIndex);
 	int ledStripIndexAfterScaling = 0;
 	int ledStripIndexBeforeScaling = 0;
@@ -105,7 +105,7 @@ void CLP::scaleSegments(FastLEDController* controller, uint8_t channelIndex, con
 	}
 }
 
-void CLP::reverse(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::reverse(FastLEDController* controller, uint8_t channelIndex) {
 	auto leds = controller->getLEDs(channelIndex);
 	auto maxIndex = controller->getLEDCount(channelIndex) - 1;
 	for (int ledIndex = 0; ledIndex < maxIndex - ledIndex; ledIndex++) {
@@ -115,7 +115,7 @@ void CLP::reverse(FastLEDController* controller, uint8_t channelIndex) {
 	}
 }
 
-void CLP::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
 	auto leds = controller->getLEDs(channelIndex);
 	auto count = controller->getLEDCount(channelIndex);
 	for (int ledIndex = 0; ledIndex < count; ledIndex++) {
@@ -125,7 +125,7 @@ void CLP::gammaCorrection(FastLEDController* controller, uint8_t channelIndex) {
 	}
 }
 
-void CLP::fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex) {
+void CorsairLightingProtocol::fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex) {
 	auto& channel = controller->getChannel(channelIndex);
 	if (channel.mode == ChannelMode::SoftwarePlayback) {
 		auto leds = controller->getLEDs(channelIndex);

--- a/src/FastLEDControllerUtils.h
+++ b/src/FastLEDControllerUtils.h
@@ -18,7 +18,7 @@
 #include "Arduino.h"
 #include "FastLEDController.h"
 
-namespace CLP {
+namespace CorsairLightingProtocol {
 /**
  * Make it possible to use up to 96 LEDs per channel from iCUE by using the LL Fan option. This function transforms the
  * LL fans layout to a normal strip layout. This function can be combined with scale and repeat function but must be
@@ -99,4 +99,4 @@ void gammaCorrection(FastLEDController* controller, uint8_t channelIndex);
  * @param channelIndex the index of the channel
  */
 void fixIcueBrightness(FastLEDController* controller, uint8_t channelIndex);
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol

--- a/src/IFanController.h
+++ b/src/IFanController.h
@@ -31,5 +31,5 @@ public:
 	 * @param command the command which must be handled
 	 * @param response the callback used for the response
 	 */
-	virtual void handleFanControl(const Command& command, const CorsairLightingProtocolResponse* response) = 0;
+	virtual void handleFanControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) = 0;
 };

--- a/src/ILEDController.h
+++ b/src/ILEDController.h
@@ -30,5 +30,5 @@ public:
 	 * @param command the command which must be handled
 	 * @param response the callback for the response
 	 */
-	virtual void handleLEDControl(const Command& command, const CorsairLightingProtocolResponse* response) = 0;
+	virtual void handleLEDControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) = 0;
 };

--- a/src/ITemperatureController.h
+++ b/src/ITemperatureController.h
@@ -30,5 +30,5 @@ public:
 	 * @param command the command which should be handled
 	 * @param response the callback for the response
 	 */
-	virtual void handleTemperatureControl(const Command& command, const CorsairLightingProtocolResponse* response) = 0;
+	virtual void handleTemperatureControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) = 0;
 };

--- a/src/LEDController.cpp
+++ b/src/LEDController.cpp
@@ -17,7 +17,7 @@
 
 #include "TemperatureController.h"
 
-void LEDController::handleLEDControl(const Command& command, const CorsairLightingProtocolResponse* response) {
+void LEDController::handleLEDControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) {
 	lastCommand = millis();
 	auto& data = command.data;
 	if (command.command == WRITE_LED_TRIGGER) {

--- a/src/LEDController.cpp
+++ b/src/LEDController.cpp
@@ -90,9 +90,9 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 				group.color3.r = data[14];
 				group.color3.g = data[15];
 				group.color3.b = data[16];
-				group.temp1 = CLP::fromBigEndian(data[17], data[18]);
-				group.temp2 = CLP::fromBigEndian(data[19], data[20]);
-				group.temp3 = CLP::fromBigEndian(data[21], data[22]);
+				group.temp1 = CorsairLightingProtocol::fromBigEndian(data[17], data[18]);
+				group.temp2 = CorsairLightingProtocol::fromBigEndian(data[19], data[20]);
+				group.temp3 = CorsairLightingProtocol::fromBigEndian(data[21], data[22]);
 
 				if (!isValidLEDGroup(group)) {
 					response->sendError();
@@ -103,7 +103,7 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 				break;
 			}
 			case WRITE_LED_EXTERNAL_TEMP: {
-				setLEDExternalTemperature(channel, CLP::fromBigEndian(data[2], data[3]));
+				setLEDExternalTemperature(channel, CorsairLightingProtocol::fromBigEndian(data[2], data[3]));
 				break;
 			}
 			case WRITE_LED_GROUPS_CLEAR: {
@@ -126,7 +126,7 @@ void LEDController::handleLEDControl(const Command& command, const CorsairLighti
 				break;
 			}
 			case WRITE_LED_BRIGHTNESS: {
-				uint8_t brightness = CLP::convert100To255(data[1]);
+				uint8_t brightness = CorsairLightingProtocol::convert100To255(data[1]);
 				triggerSave |= setLEDBrightness(channel, brightness);
 				break;
 			}

--- a/src/LEDController.h
+++ b/src/LEDController.h
@@ -160,7 +160,7 @@ struct LEDChannel {
  */
 class LEDController : public ILEDController {
 public:
-	virtual void handleLEDControl(const Command& command, const CorsairLightingProtocolResponse* response) override;
+	virtual void handleLEDControl(const CorsairLightingProtocol::Command& command, const CorsairLightingProtocolResponse* response) override;
 	/**
 	 * Validates a LEDChannel by checking all constrains on the values. This function should be used after non type-safe
 	 * operations on a LEDChannel.

--- a/src/RawHID.cpp
+++ b/src/RawHID.cpp
@@ -55,7 +55,7 @@ static const uint8_t  _hidReportDescriptorRawHID[] PROGMEM = {
 
 const char defaultSerialNumber[] PROGMEM = SERIAL_NUMBER;
 
-CLP::RawHID_::RawHID_(void)
+CorsairLightingProtocol::RawHID_::RawHID_(void)
 	: PluggableUSBModule(ENDPOINT_COUNT, 1, epType),
 	  protocol(HID_REPORT_PROTOCOL),
 	  idle(1),
@@ -70,9 +70,9 @@ CLP::RawHID_::RawHID_(void)
 	PluggableUSB().plug(this);
 }
 
-void CLP::RawHID_::setSerialNumber(const char* argSerialNumber) { serialNumber = argSerialNumber; }
+void CorsairLightingProtocol::RawHID_::setSerialNumber(const char* argSerialNumber) { serialNumber = argSerialNumber; }
 
-int CLP::RawHID_::getInterface(uint8_t* interfaceCount) {
+int CorsairLightingProtocol::RawHID_::getInterface(uint8_t* interfaceCount) {
 	// Maybe as optional device FastRawHID with different USAGE PAGE
 	*interfaceCount += 1;  // uses 1
 	HIDDescriptor hidInterface = {D_INTERFACE(pluggedInterface, ENDPOINT_COUNT, USB_DEVICE_CLASS_HUMAN_INTERFACE,
@@ -83,7 +83,7 @@ int CLP::RawHID_::getInterface(uint8_t* interfaceCount) {
 	return USB_SendControl(0, &hidInterface, sizeof(hidInterface));
 }
 
-int CLP::RawHID_::getDescriptor(USBSetup& setup) {
+int CorsairLightingProtocol::RawHID_::getDescriptor(USBSetup& setup) {
 	// Check if this is a HID Class Descriptor request
 	if (setup.bmRequestType != REQUEST_DEVICETOHOST_STANDARD_INTERFACE) {
 		return 0;
@@ -104,7 +104,7 @@ int CLP::RawHID_::getDescriptor(USBSetup& setup) {
 	return USB_SendControl(TRANSFER_PGM, _hidReportDescriptorRawHID, sizeof(_hidReportDescriptorRawHID));
 }
 
-bool CLP::RawHID_::setup(USBSetup& setup) {
+bool CorsairLightingProtocol::RawHID_::setup(USBSetup& setup) {
 	if (pluggedInterface != setup.wIndex) {
 		return false;
 	}
@@ -165,12 +165,12 @@ bool CLP::RawHID_::setup(USBSetup& setup) {
 	return false;
 }
 
-uint8_t CLP::RawHID_::getShortName(char* name) {
+uint8_t CorsairLightingProtocol::RawHID_::getShortName(char* name) {
 	name[0] = '\0';
 	strncat_P(name, serialNumber, ISERIAL_MAX_LEN - 1);
 	return strlen(name);
 }
-namespace CLP {
+namespace CorsairLightingProtocol {
 RawHID_ RawHID;
 }
 #endif

--- a/src/RawHID.h
+++ b/src/RawHID.h
@@ -57,7 +57,7 @@ THE SOFTWARE.
 // HID Functional Characteristics HID1.11 Page 10 4.4 Interfaces
 // Interrupt Out Endpoint is optional, control endpoint is used by default
 #define ENDPOINT_COUNT 1
-namespace CLP {
+namespace CorsairLightingProtocol {
 class RawHID_ : public PluggableUSBModule, public Stream {
 public:
 	RawHID_(void);
@@ -164,5 +164,5 @@ protected:
 	int featureLength;
 };
 extern RawHID_ RawHID;
-}  // namespace CLP
+}  // namespace CorsairLightingProtocol
 #endif

--- a/src/TemperatureController.cpp
+++ b/src/TemperatureController.cpp
@@ -17,7 +17,7 @@
 
 #include "CLPUtils.h"
 
-void TemperatureController::handleTemperatureControl(const Command& command,
+void TemperatureController::handleTemperatureControl(const CorsairLightingProtocol::Command& command,
 													 const CorsairLightingProtocolResponse* response) {
 	switch (command.command) {
 		case READ_TEMPERATURE_MASK: {

--- a/src/TemperatureController.h
+++ b/src/TemperatureController.h
@@ -37,7 +37,7 @@
  */
 class TemperatureController : public ITemperatureController {
 public:
-	virtual void handleTemperatureControl(const Command& command,
+	virtual void handleTemperatureControl(const CorsairLightingProtocol::Command& command,
 										  const CorsairLightingProtocolResponse* response) override;
 	/**
 	 * Get the temperature of a sensor.


### PR DESCRIPTION
rename existing namespace
add namespace CorsairLightingProtocol close #168
rename some free functions

Todo:
 - [ ] add namespace CorsairLightingProtocol
 - [ ] rename some free functions
 - [x] add `using namespace CorsairLightingProtocol;` to every sketch
 - [ ] create migration guide
 - [ ] update documentation