### PR TITLE
Fixed firmware version not read correctly

### DIFF
--- a/src/CorsairLightingFirmware.cpp
+++ b/src/CorsairLightingFirmware.cpp
@@ -32,7 +32,7 @@ void CorsairLightingFirmware::handleFirmwareCommand(const Command& command,
 			break;
 		}
 		case READ_FIRMWARE_VERSION: {
-			response->send_P(firmwareVersions[product], FIRMWARE_VERSION_SIZE);
+			response->send_P(pgm_read_word(&(firmwareVersions[product])), FIRMWARE_VERSION_SIZE);
 			break;
 		}
 		case READ_DEVICE_ID: {


### PR DESCRIPTION
@Spegs21 I found a small bug in your refactoring of the firmware handling. The PROGMEM pointer of the firmware version array was not correctly read and caused iCUE to see wrong data.

Do you know how we can make the fix also work on 32 bit processors?